### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Keep each user-visible change in its own bullet. Write the English text first, t
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-12
+
 ### Added / 新增
 
 - AI Pet Maker now includes a Universal Pet Maker Skill manager for the provider-neutral `agent-pet-maker` workflow. Users can inspect its requirements and versions, install or adopt it only at `~/agent/skills/agent-pet-maker`, update or reinstall the complete App-managed directory, reveal it in Finder, and explicitly uninstall it. The App does not infer whether an Agent discovers that directory and preserves unowned conflicting content.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petcore"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "hex",
  "image",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-cli"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "petcore",
  "petcore-types",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-types"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/petcore-cli/Cargo.toml
+++ b/crates/petcore-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-cli"
-version = "0.3.6"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore-types/Cargo.toml
+++ b/crates/petcore-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-types"
-version = "0.3.6"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore/Cargo.toml
+++ b/crates/petcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore"
-version = "0.3.6"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
## Summary

- Freeze the accumulated user-visible changes as Agent Pet Companion 0.4.0.
- Keep a fresh empty Unreleased section for subsequent work.
- Align PetCore, CLI, types, and Cargo.lock versions.

## Validation

- ./script/validate_pre_push.sh
- ./script/validate_codex_plugin_version.py --base-ref v0.3.6
- cargo metadata --no-deps --format-version 1