### PR TITLE
Prepare Agent Pet Companion 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Keep each user-visible change in its own bullet. Write the English text first, t
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-12
+
 ### Fixed / 修复
 
 - The Control Center now defers its first appearance reveal until SwiftUI finishes the current render pass, preventing the installed macOS App from opening with a blank main window.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petcore"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "hex",
  "image",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "petcore",
  "petcore-types",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-types"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/petcore-cli/Cargo.toml
+++ b/crates/petcore-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore-types/Cargo.toml
+++ b/crates/petcore-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-types"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore/Cargo.toml
+++ b/crates/petcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
## Summary

- set the App, PetCore, and CLI source version to 0.4.1
- finalize the blank Control Center window fix as the 0.4.1 changelog section
- leave the independent Codex plugin and bundled Skill version at 0.5.6 because those sources are unchanged

## Why

GitHub Release requires the source version, changelog section, protected tag, and exact main commit to agree before it can build or publish artifacts.

## Validation

- `git diff --check`
- `./script/validate_codex_plugin_version.py --base-ref v0.4.0`
- `./script/validate_pre_push.sh`
