### PR TITLE
Allow App shell supporting paths

### DIFF
--- a/development/domains.json
+++ b/development/domains.json
@@ -131,6 +131,26 @@
         {
           "path": "apps/macos/Sources/AgentPetCompanion/App/AppStore.swift",
           "risk": "amber"
+        },
+        {
+          "path": "apps/macos/Tests/AgentPetCompanionTests/AgentConnectionsTests.swift",
+          "risk": "amber"
+        },
+        {
+          "path": "apps/macos/Tests/AgentPetCompanionTests/ControlCenterShellTests.swift",
+          "risk": "amber"
+        },
+        {
+          "path": "changes/unreleased/**",
+          "risk": "amber"
+        },
+        {
+          "path": "docs/architecture/overview.md",
+          "risk": "amber"
+        },
+        {
+          "path": "docs/integrations/agent-connectors.md",
+          "risk": "amber"
         }
       ],
       "durable_document": "docs/architecture/overview.md",


### PR DESCRIPTION
## Development claim / 开发声明

- Domain: `release-control-plane`
- Claim: `control-plane`
- Base commit: `c895301268e346b7bba3ad6cf04381bef9ba4138`
- Release preparation: `no`
- Focused validation:
  - `python3 script/tests/test_validation_tooling.py`
  - `./script/validate_build_scripts_safety.sh --static-only`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":0,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-12T14:10:21Z","train_conflict_resolutions":0} -->