### PR TITLE
Run full Agent connection checks at launch

### DIFF
--- a/apps/macos/Sources/AgentPetCompanion/App/AppStore.swift
+++ b/apps/macos/Sources/AgentPetCompanion/App/AppStore.swift
@@ -604,6 +604,14 @@ enum AppUpdateConvergenceState: Equatable {
     case needsAttention(AppUpdateConvergenceAttention)
 }
 
+enum AppStartupConnectionCheckState: Equatable {
+    case idle
+    case waiting
+    case checking
+    case completed
+    case failed(AgentConnectionOperationFailureReason)
+}
+
 @MainActor
 final class AppStore: ObservableObject {
     typealias BundledPetSeeder = @MainActor () async -> Bool
@@ -745,6 +753,8 @@ final class AppStore: ObservableObject {
     @Published private(set) var portableMakerSkillOperation = PortableMakerSkillOperation.idle
     @Published private(set) var portableMakerSkillFailure: PortableMakerSkillFailure?
     @Published private(set) var manualAppInstallationRequest: AppManualInstallationRequest?
+    @Published private(set) var startupConnectionCheckState =
+        AppStartupConnectionCheckState.idle
     @Published private(set) var appUpdateConvergenceState = AppUpdateConvergenceState.idle {
         didSet {
             if case let .needsAttention(attention) = appUpdateConvergenceState {
@@ -831,6 +841,7 @@ final class AppStore: ObservableObject {
     private var runtimeBootstrap: (id: UInt64, task: Task<Bool, Never>)?
     private var runtimeBootstrapRetryTask: Task<Void, Never>?
     private var runtimeBootstrapRetryDelaySeconds: UInt64 = 2
+    private var startupConnectionCheckTask: Task<Void, Never>?
     private var bundledPetSeedRetryTask: Task<Void, Never>?
     private var initialAppearanceFallbackTask: Task<Void, Never>?
     private var recoverySequence: UInt64 = 0
@@ -1019,6 +1030,10 @@ final class AppStore: ObservableObject {
                 self?.statusText = status
             },
             failureSink: { [weak self] operation, reason in
+                self?.finishStartupConnectionCheckIfNeeded(
+                    operation: operation,
+                    result: .failure(reason)
+                )
                 self?.diagnostics.log(
                     .error,
                     category: "connections",
@@ -1031,6 +1046,9 @@ final class AppStore: ObservableObject {
                 )
             },
             checkedSink: { [weak self] sources in
+                self?.finishStartupConnectionCheckIfNeeded(
+                    checkedSources: sources
+                )
                 self?.reconcileProductConvergenceConnectorAttention(
                     afterChecking: sources
                 )
@@ -2147,7 +2165,32 @@ final class AppStore: ObservableObject {
             }
         }
         scheduleProductConvergence(bundledPetsReady: bundledPetsReady)
+        scheduleStartupConnectionCheck()
         appUpdater.checkAutomaticallyIfDue()
+    }
+
+    /// Runs one authoritative four-Agent runtime check for this App process.
+    /// Product convergence retains priority because it may refresh the same
+    /// managed host artifacts; the startup check begins as soon as that flow
+    /// and any user-started connection operation release the shared gate.
+    func scheduleStartupConnectionCheck() {
+        guard startupConnectionCheckState == .idle else { return }
+        startupConnectionCheckState = .waiting
+        startupConnectionCheckTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                if self.productConvergenceTask == nil,
+                   self.connectionsModel.canStartOperation
+                {
+                    self.startupConnectionCheckState = .checking
+                    self.connectionsModel.checkAll()
+                    self.startupConnectionCheckTask = nil
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(200))
+            }
+            self?.startupConnectionCheckTask = nil
+        }
     }
 
     @discardableResult
@@ -6927,6 +6970,44 @@ final class AppStore: ObservableObject {
         )
         if fullyResolved {
             scheduleProductConvergence(force: true)
+        }
+    }
+
+    private enum StartupConnectionCheckResult {
+        case success
+        case failure(AgentConnectionOperationFailureReason)
+    }
+
+    private func finishStartupConnectionCheckIfNeeded(
+        checkedSources: Set<AgentSource>
+    ) {
+        guard checkedSources == Set(AgentSource.allCases) else { return }
+        finishStartupConnectionCheckIfNeeded(
+            operation: AgentConnectionOperation(
+                kind: .check,
+                sources: AgentSource.allCases
+            ),
+            result: .success
+        )
+    }
+
+    private func finishStartupConnectionCheckIfNeeded(
+        operation: AgentConnectionOperation,
+        result: StartupConnectionCheckResult
+    ) {
+        guard startupConnectionCheckState != .idle,
+              operation.kind == .check,
+              operation.sources == AgentSource.allCases
+        else { return }
+
+        startupConnectionCheckTask?.cancel()
+        startupConnectionCheckTask = nil
+
+        switch result {
+        case .success:
+            startupConnectionCheckState = .completed
+        case let .failure(reason):
+            startupConnectionCheckState = .failed(reason)
         }
     }
 

--- a/apps/macos/Sources/AgentPetCompanion/App/LocalizationKeys/CommonLocalizationKeys.swift
+++ b/apps/macos/Sources/AgentPetCompanion/App/LocalizationKeys/CommonLocalizationKeys.swift
@@ -70,6 +70,16 @@ extension APCLocalizationKey {
     static let commonImagesFormat = APCLocalizationKey("common.images.format", table: .common)
     static let commonValueOfTotalFormat = APCLocalizationKey("common.value_of_total.format", table: .common)
     static let appActionCheckConnections = APCLocalizationKey("app.action.check_connections", table: .common)
+    static let appAgentConnectionsCheckingTitle = APCLocalizationKey("app.agent_connections.checking.title", table: .common)
+    static let appAgentConnectionsCheckingDetail = APCLocalizationKey("app.agent_connections.checking.detail", table: .common)
+    static let appAgentConnectionsAttentionTitle = APCLocalizationKey("app.agent_connections.attention.title", table: .common)
+    static let appAgentConnectionsAttentionDetailFormat = APCLocalizationKey("app.agent_connections.attention.detail_format", table: .common)
+    static let appAgentConnectionsCheckFailedTitle = APCLocalizationKey("app.agent_connections.check_failed.title", table: .common)
+    static let appAgentConnectionsCheckFailedDetailFormat = APCLocalizationKey("app.agent_connections.check_failed.detail_format", table: .common)
+    static let appAgentConnectionsIssueSourceFormat = APCLocalizationKey("app.agent_connections.issue.source_format", table: .common)
+    static let appAgentConnectionsIssuePluginUpdate = APCLocalizationKey("app.agent_connections.issue.plugin_update", table: .common)
+    static let appAgentConnectionsIssuePathConflict = APCLocalizationKey("app.agent_connections.issue.path_conflict", table: .common)
+    static let appAgentConnectionsIssueIncomplete = APCLocalizationKey("app.agent_connections.issue.incomplete", table: .common)
     static let appActionShowPet = APCLocalizationKey("app.action.show_pet", table: .common)
     static let appActionHidePet = APCLocalizationKey("app.action.hide_pet", table: .common)
     static let appActionMore = APCLocalizationKey("app.action.more", table: .common)
@@ -205,6 +215,16 @@ extension APCLocalizationKey {
         .commonImagesFormat,
         .commonValueOfTotalFormat,
         .appActionCheckConnections,
+        .appAgentConnectionsCheckingTitle,
+        .appAgentConnectionsCheckingDetail,
+        .appAgentConnectionsAttentionTitle,
+        .appAgentConnectionsAttentionDetailFormat,
+        .appAgentConnectionsCheckFailedTitle,
+        .appAgentConnectionsCheckFailedDetailFormat,
+        .appAgentConnectionsIssueSourceFormat,
+        .appAgentConnectionsIssuePluginUpdate,
+        .appAgentConnectionsIssuePathConflict,
+        .appAgentConnectionsIssueIncomplete,
         .appActionShowPet,
         .appActionHidePet,
         .appActionMore,

--- a/apps/macos/Sources/AgentPetCompanion/Resources/Localization/Common/Common.xcstrings
+++ b/apps/macos/Sources/AgentPetCompanion/Resources/Localization/Common/Common.xcstrings
@@ -273,6 +273,166 @@
         }
       }
     },
+    "app.agent_connections.attention.detail_format": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@. Open Agent Connections for the exact recovery steps."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@。打开“Agent 连接”查看具体处理步骤。"
+          }
+        }
+      }
+    },
+    "app.agent_connections.attention.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent connections need attention"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent 连接需要处理"
+          }
+        }
+      }
+    },
+    "app.agent_connections.check_failed.detail_format": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Open Agent Connections to retry and view recovery steps."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 请打开“Agent 连接”重试并查看处理步骤。"
+          }
+        }
+      }
+    },
+    "app.agent_connections.check_failed.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent connection operation did not finish"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent 连接操作未完成"
+          }
+        }
+      }
+    },
+    "app.agent_connections.checking.detail": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The App is running a full check of Codex, Claude Code, Pi, and OpenCode for this launch."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本次启动正在对 Codex、Claude Code、Pi 与 OpenCode 执行一次完整检查。"
+          }
+        }
+      }
+    },
+    "app.agent_connections.checking.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking Agent connections"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查 Agent 连接"
+          }
+        }
+      }
+    },
+    "app.agent_connections.issue.incomplete": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full connection result is incomplete"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完整连接检查结果不完整"
+          }
+        }
+      }
+    },
+    "app.agent_connections.issue.path_conflict": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-managed plugin or connector path conflict"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App 管理的插件或连接器路径冲突"
+          }
+        }
+      }
+    },
+    "app.agent_connections.issue.plugin_update": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-managed plugin or connector needs setup or update"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App 管理的插件或连接器需要设置或更新"
+          }
+        }
+      }
+    },
+    "app.agent_connections.issue.source_format": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@：%@"
+          }
+        }
+      }
+    },
     "app.help.hide_pet": {
       "localizations": {
         "en": {

--- a/apps/macos/Sources/AgentPetCompanion/Resources/Localization/Common/en.lproj/Common.strings
+++ b/apps/macos/Sources/AgentPetCompanion/Resources/Localization/Common/en.lproj/Common.strings
@@ -70,6 +70,16 @@
 "common.images.format" = "%d images";
 "common.value_of_total.format" = "%@ %d/%d";
 "app.action.check_connections" = "Check Agent Connections";
+"app.agent_connections.checking.title" = "Checking Agent connections";
+"app.agent_connections.checking.detail" = "The App is running a full check of Codex, Claude Code, Pi, and OpenCode for this launch.";
+"app.agent_connections.attention.title" = "Agent connections need attention";
+"app.agent_connections.attention.detail_format" = "%@. Open Agent Connections for the exact recovery steps.";
+"app.agent_connections.check_failed.title" = "Agent connection operation did not finish";
+"app.agent_connections.check_failed.detail_format" = "%@ Open Agent Connections to retry and view recovery steps.";
+"app.agent_connections.issue.source_format" = "%@: %@";
+"app.agent_connections.issue.plugin_update" = "App-managed plugin or connector needs setup or update";
+"app.agent_connections.issue.path_conflict" = "App-managed plugin or connector path conflict";
+"app.agent_connections.issue.incomplete" = "Full connection result is incomplete";
 "app.action.show_pet" = "Show Desktop Pet";
 "app.action.hide_pet" = "Hide Desktop Pet";
 "app.action.more" = "More";

--- a/apps/macos/Sources/AgentPetCompanion/Resources/Localization/Common/zh-Hans.lproj/Common.strings
+++ b/apps/macos/Sources/AgentPetCompanion/Resources/Localization/Common/zh-Hans.lproj/Common.strings
@@ -70,6 +70,16 @@
 "common.images.format" = "%d 张";
 "common.value_of_total.format" = "%@ %d/%d";
 "app.action.check_connections" = "检查 Agent 连接";
+"app.agent_connections.checking.title" = "正在检查 Agent 连接";
+"app.agent_connections.checking.detail" = "本次启动正在对 Codex、Claude Code、Pi 与 OpenCode 执行一次完整检查。";
+"app.agent_connections.attention.title" = "Agent 连接需要处理";
+"app.agent_connections.attention.detail_format" = "%@。打开“Agent 连接”查看具体处理步骤。";
+"app.agent_connections.check_failed.title" = "Agent 连接操作未完成";
+"app.agent_connections.check_failed.detail_format" = "%@ 请打开“Agent 连接”重试并查看处理步骤。";
+"app.agent_connections.issue.source_format" = "%@：%@";
+"app.agent_connections.issue.plugin_update" = "App 管理的插件或连接器需要设置或更新";
+"app.agent_connections.issue.path_conflict" = "App 管理的插件或连接器路径冲突";
+"app.agent_connections.issue.incomplete" = "完整连接检查结果不完整";
 "app.action.show_pet" = "显示桌宠";
 "app.action.hide_pet" = "隐藏桌宠";
 "app.action.more" = "更多";

--- a/apps/macos/Sources/AgentPetCompanion/Views/ContentView.swift
+++ b/apps/macos/Sources/AgentPetCompanion/Views/ContentView.swift
@@ -33,6 +33,25 @@ struct ContentView: View {
                             }
                             .padding(.horizontal, 24)
                             .padding(.top, 14)
+                            if let agentConnectionBanner,
+                               store.selection != .connections
+                            {
+                                InlineRecoveryBanner(
+                                    identity: ProductComponentIdentity(
+                                        scope: "shell",
+                                        instance: "agent-connections"
+                                    ),
+                                    status: agentConnectionBanner.status,
+                                    primaryAction: agentConnectionBanner.primaryAction
+                                ) { action in
+                                    switch action {
+                                    case .openConnections:
+                                        store.selection = .connections
+                                    }
+                                }
+                                .padding(.horizontal, 24)
+                                .padding(.top, 14)
+                            }
                             if let recoveryBanner,
                                store.selection != .diagnostics
                             {
@@ -173,6 +192,16 @@ struct ContentView: View {
     private var recoveryBanner: ControlCenterRecoveryBannerPresentation? {
         ControlCenterRecoveryBannerPresentation.resolve(
             for: store.petCoreOperationalState
+        )
+    }
+
+    private var agentConnectionBanner: ControlCenterAgentConnectionBannerPresentation? {
+        ControlCenterAgentConnectionBannerPresentation.resolve(
+            startupState: store.startupConnectionCheckState,
+            connections: store.connections,
+            operationState: store.connectionOperationState,
+            serviceState: store.petCoreOperationalState,
+            convergenceState: store.appUpdateConvergenceState
         )
     }
 }

--- a/apps/macos/Sources/AgentPetCompanion/Views/ControlCenterShell.swift
+++ b/apps/macos/Sources/AgentPetCompanion/Views/ControlCenterShell.swift
@@ -185,6 +185,228 @@ struct ControlCenterRecoveryBannerPresentation: Equatable {
     }
 }
 
+enum ControlCenterAgentConnectionAction: Hashable {
+    case openConnections
+}
+
+struct ControlCenterAgentConnectionBannerPresentation: Equatable {
+    let status: ProductStatusPresentation
+    let primaryAction: ProductActionPresentation<ControlCenterAgentConnectionAction>
+    let affectedSources: [AgentSource]
+
+    static func resolve(
+        startupState: AppStartupConnectionCheckState,
+        connections: [AgentConnectionStatus],
+        operationState: AgentConnectionOperationState,
+        serviceState: PetCoreOperationalState,
+        convergenceState: AppUpdateConvergenceState,
+        localeIdentifier: String = APCLocalization.interfaceLocaleIdentifier
+    ) -> Self? {
+        guard serviceState == .online else { return nil }
+        if case .needsAttention(.connectors) = convergenceState {
+            // The post-update banner already names the affected Agents and
+            // owns its scoped recovery/recheck actions.
+            return nil
+        }
+
+        if case let .failed(failure) = operationState {
+            return failed(
+                reason: failure.reason,
+                sources: failure.operation.sources,
+                localeIdentifier: localeIdentifier
+            )
+        }
+
+        switch startupState {
+        case .idle, .waiting:
+            return nil
+        case .checking:
+            return checking(localeIdentifier: localeIdentifier)
+        case let .failed(reason):
+            return failed(
+                reason: reason,
+                sources: AgentSource.allCases,
+                localeIdentifier: localeIdentifier
+            )
+        case .completed:
+            break
+        }
+
+        let issues = AgentSource.allCases.compactMap { source in
+            issue(
+                for: source,
+                status: connections.first { $0.source == source },
+                localeIdentifier: localeIdentifier
+            )
+        }
+        guard !issues.isEmpty else { return nil }
+
+        let detail = issues.map { issue in
+            APCLocalization.format(
+                .appAgentConnectionsIssueSourceFormat,
+                locale: localeIdentifier,
+                issue.source.title,
+                issue.summary
+            )
+        }.joined(separator: localeIdentifier.lowercased().hasPrefix("zh") ? "；" : "; ")
+
+        return Self(
+            status: ProductStatusPresentation(
+                appearance: .attention,
+                title: APCLocalization.text(
+                    .appAgentConnectionsAttentionTitle,
+                    locale: localeIdentifier
+                ),
+                detail: APCLocalization.format(
+                    .appAgentConnectionsAttentionDetailFormat,
+                    locale: localeIdentifier,
+                    detail
+                )
+            ),
+            primaryAction: openConnectionsAction(localeIdentifier: localeIdentifier),
+            affectedSources: issues.map(\.source)
+        )
+    }
+
+    private struct Issue {
+        let source: AgentSource
+        let summary: String
+    }
+
+    private static func issue(
+        for source: AgentSource,
+        status: AgentConnectionStatus?,
+        localeIdentifier: String
+    ) -> Issue? {
+        let presentation = AgentConnectionProductPresentation(
+            source: source,
+            status: status,
+            operationState: .idle
+        )
+        guard let status, presentation.hasCurrentTypedSnapshot else {
+            return Issue(
+                source: source,
+                summary: APCLocalization.text(
+                    .appAgentConnectionsIssueIncomplete,
+                    locale: localeIdentifier
+                )
+            )
+        }
+        if status.hasManagedPathConflict {
+            return Issue(
+                source: source,
+                summary: APCLocalization.text(
+                    .appAgentConnectionsIssuePathConflict,
+                    locale: localeIdentifier
+                )
+            )
+        }
+        if presentation.health == .needsRepair
+            || presentation.managedComponents.contains(where: managedComponentNeedsUpdate)
+        {
+            return Issue(
+                source: source,
+                summary: APCLocalization.text(
+                    .appAgentConnectionsIssuePluginUpdate,
+                    locale: localeIdentifier
+                )
+            )
+        }
+        if AgentConnectionsPresentation.attentionReason(for: presentation) != nil {
+            return Issue(
+                source: source,
+                summary: AgentConnectionsPresentation.healthTitle(
+                    for: presentation,
+                    locale: localeIdentifier
+                )
+            )
+        }
+        if presentation.health == .notChecked || presentation.health == .unavailable {
+            return Issue(
+                source: source,
+                summary: APCLocalization.text(
+                    .appAgentConnectionsIssueIncomplete,
+                    locale: localeIdentifier
+                )
+            )
+        }
+        return nil
+    }
+
+    private static func managedComponentNeedsUpdate(
+        _ component: AgentManagedComponent
+    ) -> Bool {
+        component.status.isBlocking
+            || component.contentMatches == false
+            || (
+                component.expectedVersion != nil
+                    && component.activeVersion != nil
+                    && component.expectedVersion != component.activeVersion
+            )
+    }
+
+    private static func checking(localeIdentifier: String) -> Self {
+        Self(
+            status: ProductStatusPresentation(
+                appearance: .checking,
+                title: APCLocalization.text(
+                    .appAgentConnectionsCheckingTitle,
+                    locale: localeIdentifier
+                ),
+                detail: APCLocalization.text(
+                    .appAgentConnectionsCheckingDetail,
+                    locale: localeIdentifier
+                )
+            ),
+            primaryAction: openConnectionsAction(localeIdentifier: localeIdentifier),
+            affectedSources: AgentSource.allCases
+        )
+    }
+
+    private static func failed(
+        reason: AgentConnectionOperationFailureReason,
+        sources: [AgentSource],
+        localeIdentifier: String
+    ) -> Self {
+        Self(
+            status: ProductStatusPresentation(
+                appearance: .error,
+                title: APCLocalization.text(
+                    .appAgentConnectionsCheckFailedTitle,
+                    locale: localeIdentifier
+                ),
+                detail: APCLocalization.format(
+                    .appAgentConnectionsCheckFailedDetailFormat,
+                    locale: localeIdentifier,
+                    AgentConnectionsPresentation.operationFailureDetail(
+                        reason,
+                        locale: localeIdentifier
+                    )
+                )
+            ),
+            primaryAction: openConnectionsAction(localeIdentifier: localeIdentifier),
+            affectedSources: sources
+        )
+    }
+
+    private static func openConnectionsAction(
+        localeIdentifier: String
+    ) -> ProductActionPresentation<ControlCenterAgentConnectionAction> {
+        ProductActionPresentation(
+            action: .openConnections,
+            title: APCLocalization.text(
+                .navigationConnections,
+                locale: localeIdentifier
+            ),
+            systemImage: "link",
+            accessibilityLabel: APCLocalization.text(
+                .appActionCheckConnections,
+                locale: localeIdentifier
+            )
+        )
+    }
+}
+
 private struct ControlCenterShellModeKey: EnvironmentKey {
     static let defaultValue = ControlCenterShellMode.allColumns
 }

--- a/apps/macos/Tests/AgentPetCompanionTests/AgentConnectionsTests.swift
+++ b/apps/macos/Tests/AgentPetCompanionTests/AgentConnectionsTests.swift
@@ -35,6 +35,26 @@ struct AgentConnectionsTests {
         #expect(!source.contains("@EnvironmentObject private var store: AppStore"))
     }
 
+    @Test
+    func runtimeBootstrapSchedulesTheLaunchWideFullCheck() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let packageRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: packageRoot.appendingPathComponent(
+                "Sources/AgentPetCompanion/App/AppStore.swift"
+            ),
+            encoding: .utf8
+        )
+        let expression = try Regex(
+            #"private func completeRuntimeBootstrap\(\) async \{[\s\S]*?scheduleProductConvergence\(bundledPetsReady: bundledPetsReady\)[\s\S]*?scheduleStartupConnectionCheck\(\)"#
+        )
+
+        #expect(source.firstMatch(of: expression) != nil)
+    }
+
     @MainActor
     @Test
     func automaticRuntimeCheckWaitsForStartupProjectionAndRunsOnlyOnce() async throws {
@@ -123,6 +143,109 @@ struct AgentConnectionsTests {
 
         #expect(checkCount == 0)
         #expect(store.connectionOperationState == .idle)
+    }
+
+    @MainActor
+    @Test
+    func appStartupAlwaysRunsOneFullCheckEvenWhenSnapshotLooksCurrent() async throws {
+        var checkCount = 0
+        let runtimeStatuses = AgentSource.allCases.map { source in
+            currentStatus(
+                source: source,
+                items: [item(.ok, code: .managedConnector)]
+            )
+        }
+        let response = try jsonObject(runtimeStatuses)
+        let store = AppStore(
+            bootstrapHooks: AppStoreBootstrapHooks(
+                ensureRunning: { .alreadyHealthy },
+                recover: { .alreadyHealthy },
+                refreshSnapshot: { _ in },
+                onReady: { _ in }
+            ),
+            petCoreRequestOverride: { method, params, _ in
+                #expect(method == "connections.check")
+                #expect((params as? [String: String])?.isEmpty == true)
+                checkCount += 1
+                return response
+            },
+            productConvergenceManifest: nil
+        )
+        store.connections = runtimeStatuses
+
+        store.scheduleStartupConnectionCheck()
+        for _ in 0..<1_000 where
+            checkCount == 0 || store.connectionOperationState.isRunning
+        {
+            try await Task.sleep(for: .milliseconds(2))
+        }
+
+        #expect(checkCount == 1)
+        #expect(store.startupConnectionCheckState == .completed)
+        #expect(
+            store.connectionOperationState.succeededOperation
+                == AgentConnectionOperation(
+                    kind: .check,
+                    sources: AgentSource.allCases
+                )
+        )
+
+        store.scheduleStartupConnectionCheck()
+        for _ in 0..<20 { await Task.yield() }
+        #expect(checkCount == 1)
+    }
+
+    @MainActor
+    @Test
+    func successfulFullRetryClearsAStartupCheckFailure() async throws {
+        var attempt = 0
+        let runtimeStatuses = AgentSource.allCases.map { source in
+            currentStatus(
+                source: source,
+                items: [item(.ok, code: .managedConnector)]
+            )
+        }
+        let response = try jsonObject(runtimeStatuses)
+        let store = AppStore(
+            bootstrapHooks: AppStoreBootstrapHooks(
+                ensureRunning: { .alreadyHealthy },
+                recover: { .alreadyHealthy },
+                refreshSnapshot: { _ in },
+                onReady: { _ in }
+            ),
+            petCoreRequestOverride: { _, _, _ in
+                attempt += 1
+                if attempt == 1 {
+                    throw AgentConnectionOperationExecutionError(
+                        .transportUnavailable
+                    )
+                }
+                return response
+            },
+            productConvergenceManifest: nil
+        )
+        store.connections = runtimeStatuses
+
+        store.scheduleStartupConnectionCheck()
+        for _ in 0..<1_000 where store.startupConnectionCheckState != .failed(
+            .transportUnavailable
+        ) {
+            try await Task.sleep(for: .milliseconds(2))
+        }
+        #expect(
+            store.startupConnectionCheckState == .failed(.transportUnavailable)
+        )
+
+        store.retryConnectionOperation()
+        for _ in 0..<1_000 where
+            store.startupConnectionCheckState != .completed
+                || store.connectionOperationState.isRunning
+        {
+            try await Task.sleep(for: .milliseconds(2))
+        }
+
+        #expect(attempt == 2)
+        #expect(store.startupConnectionCheckState == .completed)
     }
 
     @MainActor

--- a/apps/macos/Tests/AgentPetCompanionTests/ControlCenterShellTests.swift
+++ b/apps/macos/Tests/AgentPetCompanionTests/ControlCenterShellTests.swift
@@ -172,6 +172,110 @@ struct ControlCenterShellTests {
     }
 
     @Test
+    func startupConnectionCheckAndConcreteIssuesUseOneGlobalRoute() throws {
+        let checking = try #require(
+            ControlCenterAgentConnectionBannerPresentation.resolve(
+                startupState: .checking,
+                connections: [],
+                operationState: .idle,
+                serviceState: .online,
+                convergenceState: .idle,
+                localeIdentifier: "zh-Hans"
+            )
+        )
+        #expect(checking.status.appearance == .checking)
+        #expect(checking.status.title == "正在检查 Agent 连接")
+        #expect(checking.primaryAction.action == .openConnections)
+
+        let pluginUpdate = connectionStatus(
+            source: .codex,
+            checkStatus: .needsFix,
+            managedComponentStatus: .needsFix
+        )
+        let healthy = AgentSource.allCases.dropFirst().map {
+            connectionStatus(source: $0)
+        }
+        let attention = try #require(
+            ControlCenterAgentConnectionBannerPresentation.resolve(
+                startupState: .completed,
+                connections: [pluginUpdate] + healthy,
+                operationState: .succeeded(.init(
+                    kind: .check,
+                    sources: AgentSource.allCases
+                )),
+                serviceState: .online,
+                convergenceState: .idle,
+                localeIdentifier: "zh-Hans"
+            )
+        )
+
+        #expect(attention.status.appearance == .attention)
+        #expect(attention.affectedSources == [.codex])
+        #expect(attention.status.detail?.contains("Codex") == true)
+        #expect(attention.status.detail?.contains("插件或连接器需要设置或更新") == true)
+        #expect(attention.primaryAction.title == "Agent 连接")
+    }
+
+    @Test
+    func awaitingRealTaskVerificationIsNotReportedAsAConnectionFailure() {
+        let statuses = AgentSource.allCases.map {
+            connectionStatus(source: $0, verification: .unverified)
+        }
+
+        #expect(ControlCenterAgentConnectionBannerPresentation.resolve(
+            startupState: .completed,
+            connections: statuses,
+            operationState: .succeeded(.init(
+                kind: .check,
+                sources: AgentSource.allCases
+            )),
+            serviceState: .online,
+            convergenceState: .idle,
+            localeIdentifier: "en"
+        ) == nil)
+    }
+
+    @Test
+    func connectionCheckFailureAndUpdateAttentionDoNotDuplicateBanners() throws {
+        let failedOperation = AgentConnectionOperation(
+            kind: .check,
+            sources: AgentSource.allCases
+        )
+        let failure = try #require(
+            ControlCenterAgentConnectionBannerPresentation.resolve(
+                startupState: .failed(.transportUnavailable),
+                connections: [],
+                operationState: .failed(.init(
+                    operation: failedOperation,
+                    reason: .transportUnavailable
+                )),
+                serviceState: .online,
+                convergenceState: .idle,
+                localeIdentifier: "en"
+            )
+        )
+        #expect(failure.status.appearance == .error)
+        #expect(failure.status.title == "Agent connection operation did not finish")
+        #expect(failure.primaryAction.action == .openConnections)
+
+        let updateIssue = ProductConnectorConvergenceIssue(
+            source: .codex,
+            reason: .verificationIncomplete
+        )
+        #expect(ControlCenterAgentConnectionBannerPresentation.resolve(
+            startupState: .failed(.transportUnavailable),
+            connections: [],
+            operationState: .failed(.init(
+                operation: failedOperation,
+                reason: .transportUnavailable
+            )),
+            serviceState: .online,
+            convergenceState: .needsAttention(.connectors([updateIssue])),
+            localeIdentifier: "en"
+        ) == nil)
+    }
+
+    @Test
     func toolbarContainsNoOverflowNavigationDuplicate() throws {
         let contentSource = try String(
             contentsOf: sourceDirectory.appendingPathComponent(
@@ -239,5 +343,58 @@ struct ControlCenterShellTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Sources/AgentPetCompanion", isDirectory: true)
+    }
+
+    private func connectionStatus(
+        source: AgentSource,
+        checkStatus: CheckStatus = .ok,
+        managedComponentStatus: CheckStatus = .ok,
+        verification: AgentVerificationStatus = .verified
+    ) -> AgentConnectionStatus {
+        AgentConnectionStatus(
+            source: source,
+            items: [
+                ConnectionCheckItem(
+                    code: .managedConnector,
+                    name: "managed connector",
+                    status: checkStatus,
+                    detail: "bounded test detail",
+                    recoveryAction: checkStatus.isBlocking
+                        ? .confirmManagedRepair
+                        : nil
+                )
+            ],
+            installPaths: [],
+            connectorInstalled: checkStatus == .ok,
+            checkMode: .runtime,
+            verification: AgentVerification(
+                status: verification,
+                title: "verification",
+                detail: "verification detail"
+            ),
+            capabilities: AgentConnectorCapabilities(
+                contractVersion: "typed-test-v1",
+                subscribedEvents: [],
+                mappedInformation: [],
+                privacyExclusions: [],
+                repairableConnectorIssue: checkStatus.isBlocking,
+                canRepairManagedConnector: true,
+                managedPathConflict: false,
+                canUninstallManagedConnector: true,
+                managedComponents: [
+                    AgentManagedComponent(
+                        kind: .plugin,
+                        name: "agent-pet-companion",
+                        ownership: .appManaged,
+                        status: managedComponentStatus,
+                        expectedVersion: "1.1.0",
+                        activeVersion: managedComponentStatus == .ok
+                            ? "1.1.0"
+                            : "1.0.0",
+                        contentMatches: managedComponentStatus == .ok
+                    )
+                ]
+            )
+        )
     }
 }

--- a/changes/unreleased/startup-agent-connection-alert-20260812.json
+++ b/changes/unreleased/startup-agent-connection-alert-20260812.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Changed",
+  "scope": "agent-connections",
+  "summary_en": "Each App launch now runs a full Agent connection check and shows actionable global notices for plugin, connector, authorization, restart, and channel issues.",
+  "summary_zh": "App 每次启动都会完整检查 Agent 连接，并针对插件、连接器、授权、重启与通道问题显示可操作的全局提示。"
+}

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -55,7 +55,8 @@ The App composition root retains cross-feature orchestration in `AppStore`, whil
 1. The App claims its single-instance identity and checks the exact bundled runtime contract.
 2. A compatible PetCore is reused. Otherwise the App stages, preflights, replaces, verifies, and either commits or rolls back the managed runtime.
 3. The App hydrates behavior settings, converges bundled pets by stable ID, reads one authoritative `state.snapshot`, presents first run or the control center, then presents the overlay.
-4. Subsequent state arrives through revision-based `state.wait`; the App does not read SQLite or poll bundle files.
+4. After the launch-critical snapshot path and any release connector convergence complete, the App runs one full check of all four Agent connections and projects actionable failures into a control-center-wide notice that opens Agent Connections.
+5. Subsequent state arrives through revision-based `state.wait`; the App does not read SQLite or poll bundle files.
 
 Closing the control center leaves the menu bar and enabled pet running. Reopen targets the registered control-center window rather than whichever App window happens to be visible. Standard Quit closes the UI host and overlay; the LaunchAgent-hosted PetCore may remain available.
 

--- a/docs/integrations/agent-connectors.md
+++ b/docs/integrations/agent-connectors.md
@@ -97,13 +97,24 @@ PetCore supplies typed capabilities for safe repair and removal; the App never i
 Every authoritative App snapshot includes a bounded light check for all four
 Agents. Agent Connections presents a healthy light result as **Basic check
 complete** and immediately exposes specific missing-host or managed-repair
-findings; it never labels an available light result as if no check ran. The
-first Agent Connections presentation in each App session requests one full
-runtime check after all four light projections are loaded and release connector
-convergence is idle. A fresh runtime projection is reused instead of probing
-again, while **Check All** remains the explicit retry path. Full host probes stay
-out of the launch-critical path because they may cold-start Agent hosts, load
-plugins, or encounter host trust and protected-folder prompts.
+findings; it never labels an available light result as if no check ran. Every
+App launch schedules one full four-Agent runtime check after the authoritative
+light projections are loaded and release connector convergence is idle. This
+check runs even when a prior runtime projection is available, but remains
+outside the launch-critical snapshot and window-presentation path because host
+probes may cold-start Agent hosts, load plugins, or encounter host trust and
+protected-folder prompts. **Check All** remains the explicit retry path.
+
+The control-center shell shows the launch check while it runs. After completion,
+any missing host, managed plugin/connector setup or version mismatch, managed
+path conflict, Hook authorization, host permission/restart requirement, local
+event-channel failure, incomplete result, or failed connection operation is a
+global in-App notice outside Agent Connections. The notice names each affected
+Agent and its closed issue category and opens Agent Connections for the exact
+typed recovery steps. Post-update connector convergence keeps its existing
+higher-priority scoped notice so the App never duplicates the same problem.
+Healthy local integration that only awaits an ordinary real Agent task remains
+neutral and does not create a global failure notice.
 
 Agent Connections distinguishes local integration health from evidence of a real provider task. It lists only App-owned plugins, connectors, extensions, and bundled Skills with safe names and verified active/required release versions. Paths, digests, internal contract IDs, user-managed components, and unrelated runtime diagnostics remain hidden. A detected Agent host version is diagnostic context only and never gates compatibility. Health is decided by the exact App-managed connector contract, host runtime probe, local event channel, and current connector receipts, so a host upgrade does not require a new hardcoded version allowance.
 


### PR DESCRIPTION
## Development claim / 开发声明

- Domain: `app-shell-runtime`
- Claim: `app-composition`
- Base commit: `39b8243c51276cd8e7657b12c0cfce3db491d6a6`
- Release preparation: `no`
- Focused validation:
  - `./script/validate_swift_tests.sh --scope all`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":0,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-12T14:22:43Z","train_conflict_resolutions":0} -->