### PR TITLE
Prepare Agent Pet Companion 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ Keep each user-visible change in its own bullet. Write the English text first, t
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-08-12
+
+### Changed / 变更
+
+<!-- apc-fragment:501-engineering-speedup -->
+- Development work now uses typed domain claims, focused local validation, lower-cost CI, and modular Rust and Swift ownership boundaries.
+
+  开发流程现采用类型化领域声明、聚焦本地验证、更低成本的 CI，以及模块化的 Rust 与 Swift 所有权边界。
+<!-- apc-fragment:startup-agent-connection-alert-20260812 -->
+- Each App launch now runs a full Agent connection check and shows actionable global notices for plugin, connector, authorization, restart, and channel issues.
+
+  App 每次启动都会完整检查 Agent 连接，并针对插件、连接器、授权、重启与通道问题显示可操作的全局提示。
 ## [0.4.2] - 2026-08-12
 
 ### Fixed / 修复

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petcore"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "hex",
  "image",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "petcore",
  "petcore-types",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-types"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/changes/unreleased/501-engineering-speedup.json
+++ b/changes/unreleased/501-engineering-speedup.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Changed",
-  "scope": "engineering",
-  "summary_en": "Development work now uses typed domain claims, focused local validation, lower-cost CI, and modular Rust and Swift ownership boundaries.",
-  "summary_zh": "开发流程现采用类型化领域声明、聚焦本地验证、更低成本的 CI，以及模块化的 Rust 与 Swift 所有权边界。"
-}

--- a/changes/unreleased/startup-agent-connection-alert-20260812.json
+++ b/changes/unreleased/startup-agent-connection-alert-20260812.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Changed",
-  "scope": "agent-connections",
-  "summary_en": "Each App launch now runs a full Agent connection check and shows actionable global notices for plugin, connector, authorization, restart, and channel issues.",
-  "summary_zh": "App 每次启动都会完整检查 Agent 连接，并针对插件、连接器、授权、重启与通道问题显示可操作的全局提示。"
-}

--- a/crates/petcore-cli/Cargo.toml
+++ b/crates/petcore-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-cli"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore-types/Cargo.toml
+++ b/crates/petcore-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-types"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore/Cargo.toml
+++ b/crates/petcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 license.workspace = true
 

--- a/development/domains.json
+++ b/development/domains.json
@@ -546,7 +546,15 @@
           "risk": "amber"
         },
         {
+          "path": "CHANGELOG.md",
+          "risk": "amber"
+        },
+        {
           "path": "CONTRIBUTING.md",
+          "risk": "amber"
+        },
+        {
+          "path": "Cargo.lock",
           "risk": "amber"
         },
         {


### PR DESCRIPTION
## Summary

- prepare Agent Pet Companion `0.4.3` from the complete frozen two-fragment inventory
- synchronize PetCore, CLI, types, and Cargo lock identities at `0.4.3`
- declare `CHANGELOG.md` and `Cargo.lock` as typed release-preparation shared paths

## Impact

This patch release includes the engineering-speedup delivery architecture and the launch-time full Agent connection check with actionable global notices. The root changelog retains a fresh empty Unreleased section after consuming every current fragment.

## Validation

- `python3 script/development_domains.py validate`
- `python3 script/tests/test_validation_tooling.py` (52 passed)
- `./script/validate_build_scripts_safety.sh --static-only`
- `python3 script/tests/test_release_distribution_contracts.py` (44 passed)
- `cargo check --workspace --all-targets --locked`
- `./script/validate_pre_push.sh`
- `python3 script/changelog_fragments.py policy --base-ref origin/main --release-preparation true`

## Development claim / 开发声明

- Domain: `release-control-plane`
- Claim: `control-plane`
- Base commit: `df7cbe07d537ec44a23600916ae3e527971e9b79`
- Release preparation: `yes`
- Focused validation:
  - `python3 script/tests/test_validation_tooling.py`
  - `./script/validate_build_scripts_safety.sh --static-only`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":0,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-12T15:20:54Z","train_conflict_resolutions":0} -->