### PR TITLE
Fix false Agent connection expiry alerts

### DIFF
--- a/apps/macos/Sources/AgentPetCompanion/Views/ControlCenterShell.swift
+++ b/apps/macos/Sources/AgentPetCompanion/Views/ControlCenterShell.swift
@@ -283,7 +283,7 @@ struct ControlCenterAgentConnectionBannerPresentation: Equatable {
             status: status,
             operationState: .idle
         )
-        guard let status, presentation.hasCurrentTypedSnapshot else {
+        guard let status else {
             return Issue(
                 source: source,
                 summary: APCLocalization.text(
@@ -317,6 +317,23 @@ struct ControlCenterAgentConnectionBannerPresentation: Equatable {
                 source: source,
                 summary: AgentConnectionsPresentation.healthTitle(
                     for: presentation,
+                    locale: localeIdentifier
+                )
+            )
+        }
+        // A runtime result is intentionally cached for only a bounded period.
+        // Once it expires, PetCore resumes publishing an authoritative light
+        // snapshot. A complete, healthy light snapshot still proves that the
+        // local integration has no current actionable issue; it must not turn
+        // an earlier successful full check into an "incomplete result" alert.
+        if presentation.hasCurrentLightSnapshot {
+            return nil
+        }
+        guard presentation.hasCurrentTypedSnapshot else {
+            return Issue(
+                source: source,
+                summary: APCLocalization.text(
+                    .appAgentConnectionsIssueIncomplete,
                     locale: localeIdentifier
                 )
             )

--- a/apps/macos/Tests/AgentPetCompanionTests/ControlCenterShellTests.swift
+++ b/apps/macos/Tests/AgentPetCompanionTests/ControlCenterShellTests.swift
@@ -236,6 +236,56 @@ struct ControlCenterShellTests {
     }
 
     @Test
+    func healthyLightSnapshotsAfterRuntimeCacheExpiryDoNotCreateFalseAttention() {
+        let statuses = AgentSource.allCases.map {
+            connectionStatus(source: $0, checkMode: .light)
+        }
+
+        #expect(ControlCenterAgentConnectionBannerPresentation.resolve(
+            startupState: .completed,
+            connections: statuses,
+            operationState: .succeeded(.init(
+                kind: .check,
+                sources: AgentSource.allCases
+            )),
+            serviceState: .online,
+            convergenceState: .idle,
+            localeIdentifier: "zh-Hans"
+        ) == nil)
+    }
+
+    @Test
+    func lightSnapshotsStillReportConcreteConnectionIssues() throws {
+        let needsRepair = connectionStatus(
+            source: .codex,
+            checkStatus: .needsFix,
+            managedComponentStatus: .needsFix,
+            checkMode: .light
+        )
+        let healthy = AgentSource.allCases.dropFirst().map {
+            connectionStatus(source: $0, checkMode: .light)
+        }
+
+        let attention = try #require(
+            ControlCenterAgentConnectionBannerPresentation.resolve(
+                startupState: .completed,
+                connections: [needsRepair] + healthy,
+                operationState: .succeeded(.init(
+                    kind: .check,
+                    sources: AgentSource.allCases
+                )),
+                serviceState: .online,
+                convergenceState: .idle,
+                localeIdentifier: "zh-Hans"
+            )
+        )
+
+        #expect(attention.affectedSources == [.codex])
+        #expect(attention.status.detail?.contains("Codex") == true)
+        #expect(attention.status.detail?.contains("插件或连接器需要设置或更新") == true)
+    }
+
+    @Test
     func connectionCheckFailureAndUpdateAttentionDoNotDuplicateBanners() throws {
         let failedOperation = AgentConnectionOperation(
             kind: .check,
@@ -349,6 +399,7 @@ struct ControlCenterShellTests {
         source: AgentSource,
         checkStatus: CheckStatus = .ok,
         managedComponentStatus: CheckStatus = .ok,
+        checkMode: ConnectionCheckMode = .runtime,
         verification: AgentVerificationStatus = .verified
     ) -> AgentConnectionStatus {
         AgentConnectionStatus(
@@ -366,7 +417,7 @@ struct ControlCenterShellTests {
             ],
             installPaths: [],
             connectorInstalled: checkStatus == .ok,
-            checkMode: .runtime,
+            checkMode: checkMode,
             verification: AgentVerification(
                 status: verification,
                 title: "verification",

--- a/changes/unreleased/20260814-agent-connection-expiry-alert.json
+++ b/changes/unreleased/20260814-agent-connection-expiry-alert.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Fixed",
+  "scope": "macos",
+  "summary_en": "Prevent normal Agent runtime-check cache expiry from producing false incomplete-result alerts while preserving concrete light-check warnings.",
+  "summary_zh": "修复 Agent 完整检查缓存正常过期后误报“结果不完整”的问题，同时保留轻量检查发现的具体异常提示。"
+}

--- a/docs/integrations/agent-connectors.md
+++ b/docs/integrations/agent-connectors.md
@@ -114,7 +114,10 @@ Agent and its closed issue category and opens Agent Connections for the exact
 typed recovery steps. Post-update connector convergence keeps its existing
 higher-priority scoped notice so the App never duplicates the same problem.
 Healthy local integration that only awaits an ordinary real Agent task remains
-neutral and does not create a global failure notice.
+neutral and does not create a global failure notice. When the bounded runtime
+result cache expires, a complete healthy light snapshot is likewise neutral;
+normal cache expiry never reclassifies a successful full check as an incomplete
+result. Concrete light-check findings remain actionable and keep the notice.
 
 Agent Connections distinguishes local integration health from evidence of a real provider task. It lists only App-owned plugins, connectors, extensions, and bundled Skills with safe names and verified active/required release versions. Paths, digests, internal contract IDs, user-managed components, and unrelated runtime diagnostics remain hidden. A detected Agent host version is diagnostic context only and never gates compatibility. Health is decided by the exact App-managed connector contract, host runtime probe, local event channel, and current connector receipts, so a host upgrade does not require a new hardcoded version allowance.
 


### PR DESCRIPTION
## Development claim / 开发声明

- Domain: `app-shell-runtime`
- Claim: `app-composition`
- Base commit: `72c66a67fbd8cea9100a498dfed74bfa245cdcda`
- Release preparation: `no`
- Focused validation:
  - `./script/validate_swift_tests.sh --scope all`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":0,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-14T01:51:07Z","train_conflict_resolutions":0} -->