### PR TITLE
Make migration test timestamps dynamic

### DIFF
--- a/crates/petcore/tests/integration_a/core_validation.rs
+++ b/crates/petcore/tests/integration_a/core_validation.rs
@@ -1583,7 +1583,7 @@ fn startup_scrubs_legacy_connector_runtime_events_into_diagnostics() {
                 "interaction_kind": null,
                 "project_label": null
             }),
-            created_at: "2026-07-14T00:00:00Z".to_string(),
+            created_at: OffsetDateTime::now_utc().format(&Rfc3339).unwrap(),
         })
         .unwrap();
 
@@ -1620,7 +1620,7 @@ fn startup_reclassifies_legacy_pi_tool_errors_as_non_terminal_tool_events() {
                 "interaction_kind": null,
                 "project_label": null
             }),
-            created_at: "2026-07-14T00:00:00Z".to_string(),
+            created_at: OffsetDateTime::now_utc().format(&Rfc3339).unwrap(),
         })
         .unwrap();
 


### PR DESCRIPTION
## Summary

- replace two wall-clock-dependent hard-coded Agent event timestamps with runtime RFC 3339 values
- keep the startup migration assertions unchanged
- prevent the 30-day event-retention policy from turning these tests into calendar time bombs

## Validation

- `cargo test -p petcore --test integration_a --locked` (96 passed)
- `cargo fmt --all -- --check`
- `./script/validate_pre_push.sh`

Test-only maintenance; no production behavior or changelog entry.

## Development claim / 开发声明

- Domain: `storage-migrations`
- Claim: `agent-queries`
- Base commit: `72c66a67fbd8cea9100a498dfed74bfa245cdcda`
- Release preparation: `no`
- Target: the integration-a core validation fixture that exercises Agent-event storage migrations

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":0,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-14T02:11:48Z","train_conflict_resolutions":0} -->