### PR TITLE
Prepare Agent Pet Companion 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Keep each user-visible change in its own bullet. Write the English text first, t
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-08-14
+
+### Fixed / 修复
+
+<!-- apc-fragment:20260814-agent-connection-expiry-alert -->
+- Prevent normal Agent runtime-check cache expiry from producing false incomplete-result alerts while preserving concrete light-check warnings.
+
+  修复 Agent 完整检查缓存正常过期后误报“结果不完整”的问题，同时保留轻量检查发现的具体异常提示。
+
 ## [0.4.3] - 2026-08-13
 
 ### Changed / 变更

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petcore"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "hex",
  "image",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "petcore",
  "petcore-types",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-types"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/changes/unreleased/20260814-agent-connection-expiry-alert.json
+++ b/changes/unreleased/20260814-agent-connection-expiry-alert.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "macos",
-  "summary_en": "Prevent normal Agent runtime-check cache expiry from producing false incomplete-result alerts while preserving concrete light-check warnings.",
-  "summary_zh": "修复 Agent 完整检查缓存正常过期后误报“结果不完整”的问题，同时保留轻量检查发现的具体异常提示。"
-}

--- a/crates/petcore-cli/Cargo.toml
+++ b/crates/petcore-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-cli"
-version = "0.4.3"
+version = "0.4.4"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore-types/Cargo.toml
+++ b/crates/petcore-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-types"
-version = "0.4.3"
+version = "0.4.4"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore/Cargo.toml
+++ b/crates/petcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore"
-version = "0.4.3"
+version = "0.4.4"
 edition.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
## Summary

- prepare Agent Pet Companion `0.4.4` from the complete frozen one-fragment inventory
- synchronize PetCore, CLI, types, and Cargo lock identities at `0.4.4`
- consume the Agent connection cache-expiry alert fix into the bilingual release changelog

## Impact

This patch release prevents healthy Agent light checks from being reported as incomplete after the bounded runtime-check cache expires, while preserving actionable warnings for concrete connection problems.

## Validation

- `python3 script/development_domains.py validate` (11 domains)
- `python3 script/tests/test_validation_tooling.py` (53 passed)
- `./script/validate_build_scripts_safety.sh --static-only`
- `python3 script/tests/test_release_distribution_contracts.py` (44 passed)
- `cargo check --workspace --all-targets --locked`
- `./script/validate_pre_push.sh`
- `python3 script/changelog_fragments.py require-consumed`
- `python3 script/changelog_fragments.py policy --base-ref origin/main --release-preparation true`

## Development claim / 开发声明

- Domain: `release-control-plane`
- Claim: `control-plane`
- Base commit: `ca336d86cf58bc27f454361eda22f74dd55b447d`
- Release preparation: `yes`
- Focused validation:
  - `python3 script/tests/test_validation_tooling.py`
  - `./script/validate_build_scripts_safety.sh --static-only`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":0,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-14T07:27:17Z","train_conflict_resolutions":0} -->