### PR TITLE
Ignore uninstalled agents in global notices

### DIFF
--- a/apps/macos/Sources/AgentPetCompanion/Views/ControlCenterShell.swift
+++ b/apps/macos/Sources/AgentPetCompanion/Views/ControlCenterShell.swift
@@ -292,6 +292,14 @@ struct ControlCenterAgentConnectionBannerPresentation: Equatable {
                 )
             )
         }
+        // Agent hosts are optional. Their absence belongs only to the
+        // Agent Connections page as setup guidance, never to the global
+        // control-center problem notice.
+        if presentation.technicalItems.contains(where: { item in
+            item.code == .agentCLI && item.status == .missing
+        }) {
+            return nil
+        }
         if status.hasManagedPathConflict {
             return Issue(
                 source: source,

--- a/apps/macos/Tests/AgentPetCompanionTests/ControlCenterShellTests.swift
+++ b/apps/macos/Tests/AgentPetCompanionTests/ControlCenterShellTests.swift
@@ -236,6 +236,45 @@ struct ControlCenterShellTests {
     }
 
     @Test
+    func uninstalledAgentIsOnlyReportedOnTheConnectionsPage() throws {
+        let notInstalled = connectionStatus(
+            source: .claudeCode,
+            checkStatus: .needsFix,
+            managedComponentStatus: .needsFix,
+            agentCLIStatus: .missing
+        )
+        let statuses = [notInstalled] + AgentSource.allCases
+            .filter { $0 != .claudeCode }
+            .map { connectionStatus(source: $0) }
+
+        #expect(ControlCenterAgentConnectionBannerPresentation.resolve(
+            startupState: .completed,
+            connections: statuses,
+            operationState: .succeeded(.init(
+                kind: .check,
+                sources: AgentSource.allCases
+            )),
+            serviceState: .online,
+            convergenceState: .idle,
+            localeIdentifier: "en"
+        ) == nil)
+
+        let connectionPagePresentation = AgentConnectionProductPresentation(
+            source: .claudeCode,
+            status: notInstalled,
+            operationState: .idle
+        )
+        #expect(AgentConnectionsPresentation.healthTitle(
+            for: connectionPagePresentation,
+            locale: "en"
+        ) == "Agent Not Found")
+        #expect(AgentConnectionsPresentation.userGuidance(
+            for: connectionPagePresentation,
+            locale: "en"
+        )?.contains("Install or open") == true)
+    }
+
+    @Test
     func healthyLightSnapshotsAfterRuntimeCacheExpiryDoNotCreateFalseAttention() {
         let statuses = AgentSource.allCases.map {
             connectionStatus(source: $0, checkMode: .light)
@@ -400,11 +439,20 @@ struct ControlCenterShellTests {
         checkStatus: CheckStatus = .ok,
         managedComponentStatus: CheckStatus = .ok,
         checkMode: ConnectionCheckMode = .runtime,
-        verification: AgentVerificationStatus = .verified
+        verification: AgentVerificationStatus = .verified,
+        agentCLIStatus: CheckStatus? = nil
     ) -> AgentConnectionStatus {
         AgentConnectionStatus(
             source: source,
-            items: [
+            items: (agentCLIStatus.map { status in
+                [ConnectionCheckItem(
+                    code: .agentCLI,
+                    name: "Agent host",
+                    status: status,
+                    detail: "bounded test detail",
+                    recoveryAction: .recheck
+                )]
+            } ?? []) + [
                 ConnectionCheckItem(
                     code: .managedConnector,
                     name: "managed connector",

--- a/changes/unreleased/20260814-uninstalled-agent-global-notice.json
+++ b/changes/unreleased/20260814-uninstalled-agent-global-notice.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Fixed",
+  "scope": "macos",
+  "summary_en": "Treat an uninstalled optional Agent App or CLI as informational setup guidance on Agent Connections instead of a global connection problem.",
+  "summary_zh": "未安装可选 Agent App 或 CLI 时，仅在 Agent 连接页显示设置提示，不再归为全局连接问题。"
+}

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -55,7 +55,7 @@ The App composition root retains cross-feature orchestration in `AppStore`, whil
 1. The App claims its single-instance identity and checks the exact bundled runtime contract.
 2. A compatible PetCore is reused. Otherwise the App stages, preflights, replaces, verifies, and either commits or rolls back the managed runtime.
 3. The App hydrates behavior settings, converges bundled pets by stable ID, reads one authoritative `state.snapshot`, presents first run or the control center, then presents the overlay.
-4. After the launch-critical snapshot path and any release connector convergence complete, the App runs one full check of all four Agent connections and projects actionable failures into a control-center-wide notice that opens Agent Connections.
+4. After the launch-critical snapshot path and any release connector convergence complete, the App runs one full check of all four Agent connections and projects actionable failures into a control-center-wide notice that opens Agent Connections. An Agent App or CLI that is not installed remains informational on Agent Connections and never enters this global notice.
 5. Subsequent state arrives through revision-based `state.wait`; the App does not read SQLite or poll bundle files.
 
 Closing the control center leaves the menu bar and enabled pet running. Reopen targets the registered control-center window rather than whichever App window happens to be visible. Standard Quit closes the UI host and overlay; the LaunchAgent-hosted PetCore may remain available.

--- a/docs/integrations/agent-connectors.md
+++ b/docs/integrations/agent-connectors.md
@@ -106,18 +106,21 @@ probes may cold-start Agent hosts, load plugins, or encounter host trust and
 protected-folder prompts. **Check All** remains the explicit retry path.
 
 The control-center shell shows the launch check while it runs. After completion,
-any missing host, managed plugin/connector setup or version mismatch, managed
-path conflict, Hook authorization, host permission/restart requirement, local
-event-channel failure, incomplete result, or failed connection operation is a
-global in-App notice outside Agent Connections. The notice names each affected
-Agent and its closed issue category and opens Agent Connections for the exact
-typed recovery steps. Post-update connector convergence keeps its existing
-higher-priority scoped notice so the App never duplicates the same problem.
-Healthy local integration that only awaits an ordinary real Agent task remains
-neutral and does not create a global failure notice. When the bounded runtime
-result cache expires, a complete healthy light snapshot is likewise neutral;
-normal cache expiry never reclassifies a successful full check as an incomplete
-result. Concrete light-check findings remain actionable and keep the notice.
+managed plugin/connector setup or version mismatch, managed path conflict, Hook
+authorization, host permission/restart requirement, local event-channel
+failure, incomplete result, or failed connection operation is a global in-App
+notice outside Agent Connections. An Agent App or CLI that is not installed is
+a normal optional state: only Agent Connections shows its informational setup
+guidance, and the missing host never enters the global issue notice. The notice
+names each affected Agent and its closed issue category and opens Agent
+Connections for the exact typed recovery steps. Post-update connector
+convergence keeps its existing higher-priority scoped notice so the App never
+duplicates the same problem. Healthy local integration that only awaits an
+ordinary real Agent task remains neutral and does not create a global failure
+notice. When the bounded runtime result cache expires, a complete healthy light
+snapshot is likewise neutral; normal cache expiry never reclassifies a
+successful full check as an incomplete result. Other concrete light-check
+findings remain actionable and keep the notice.
 
 Agent Connections distinguishes local integration health from evidence of a real provider task. It lists only App-owned plugins, connectors, extensions, and bundled Skills with safe names and verified active/required release versions. Paths, digests, internal contract IDs, user-managed components, and unrelated runtime diagnostics remain hidden. A detected Agent host version is diagnostic context only and never gates compatibility. Health is decided by the exact App-managed connector contract, host runtime probe, local event channel, and current connector receipts, so a host upgrade does not require a new hardcoded version allowance.
 


### PR DESCRIPTION
## Development claim / 开发声明

- Domain: `app-shell-runtime`
- Claim: `app-composition`
- Base commit: `deeb04325510c4f05cc4382a1a89f8623fedbe17`
- Release preparation: `no`
- Focused validation:
  - `./script/validate_swift_tests.sh --scope all`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":0,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-14T11:02:29Z","train_conflict_resolutions":0} -->