### PR TITLE
Prepare Agent Pet Companion 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Keep each user-visible change in its own bullet. Write the English text first, t
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-08-14
+
+### Fixed / 修复
+
+<!-- apc-fragment:20260814-uninstalled-agent-global-notice -->
+- Treat an uninstalled optional Agent App or CLI as informational setup guidance on Agent Connections instead of a global connection problem.
+
+  未安装可选 Agent App 或 CLI 时，仅在 Agent 连接页显示设置提示，不再归为全局连接问题。
+
 ## [0.4.4] - 2026-08-14
 
 ### Fixed / 修复

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petcore"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "hex",
  "image",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-cli"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "petcore",
  "petcore-types",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-types"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/changes/unreleased/20260814-uninstalled-agent-global-notice.json
+++ b/changes/unreleased/20260814-uninstalled-agent-global-notice.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "macos",
-  "summary_en": "Treat an uninstalled optional Agent App or CLI as informational setup guidance on Agent Connections instead of a global connection problem.",
-  "summary_zh": "未安装可选 Agent App 或 CLI 时，仅在 Agent 连接页显示设置提示，不再归为全局连接问题。"
-}

--- a/crates/petcore-cli/Cargo.toml
+++ b/crates/petcore-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-cli"
-version = "0.4.4"
+version = "0.4.5"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore-types/Cargo.toml
+++ b/crates/petcore-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-types"
-version = "0.4.4"
+version = "0.4.5"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore/Cargo.toml
+++ b/crates/petcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore"
-version = "0.4.4"
+version = "0.4.5"
 edition.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
## Summary

- prepare Agent Pet Companion `0.4.5` from the complete frozen one-fragment inventory
- synchronize PetCore, CLI, types, and Cargo lock identities at `0.4.5`
- consume the optional uninstalled-Agent notice fix into the bilingual release changelog

## Impact

This patch release keeps an optional Agent App or CLI that is not installed as setup guidance inside Agent Connections instead of reporting it as a global connection problem.

## Validation

- `python3 script/development_domains.py validate` (11 domains)
- `python3 script/tests/test_validation_tooling.py` (53 passed)
- `./script/validate_build_scripts_safety.sh --static-only`
- `python3 script/tests/test_release_distribution_contracts.py` (44 passed)
- `cargo check --workspace --all-targets --locked`
- `./script/validate_pre_push.sh`
- `python3 script/changelog_fragments.py require-consumed`
- `python3 script/changelog_fragments.py policy --base-ref origin/main --release-preparation true`

## Development claim / 开发声明

- Domain: `release-control-plane`
- Claim: `control-plane`
- Base commit: `02b1256ab5277bfe762a246e326771bed930b290`
- Release preparation: `yes`
- Focused validation:
  - `python3 script/tests/test_validation_tooling.py`
  - `./script/validate_build_scripts_safety.sh --static-only`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":0,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-14T15:46:51Z","train_conflict_resolutions":0} -->