### PR TITLE
Prepare Agent Pet Companion 0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ Keep each user-visible change in its own bullet. Write the English text first, t
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-08-17
+
+### Changed / 变更
+
+<!-- apc-fragment:20260817-release-notes-version-summary -->
+- GitHub Releases now lead with the exact version change summary and follow it with concise installation guidance.
+
+  GitHub Release 现在会先展示对应版本的变更摘要，再附上精简安装说明。
+
+### Fixed / 修复
+
+<!-- apc-fragment:20260817-claude-background-idle-completion -->
+- Claude Code idle notifications no longer mark a session complete while its background agents are still working.
+
+  Claude Code 的后台 Agent 仍在工作时，空闲通知不再误将会话标记为已完成。
+<!-- apc-fragment:control-center-visibility-invariants -->
+- Control Center presentation now has one focus-safe window owner, nonblocking appearance hydration, and a repeated cold-launch release gate.
+
+  控制中心现由单一且焦点安全的窗口协调器展示，主题加载不再阻塞窗口，并新增重复冷启动发布门禁。
 ## [0.4.5] - 2026-08-14
 
 ### Fixed / 修复

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petcore"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "hex",
  "image",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "petcore",
  "petcore-types",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-types"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/changes/unreleased/20260817-claude-background-idle-completion.json
+++ b/changes/unreleased/20260817-claude-background-idle-completion.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "connections",
-  "summary_en": "Claude Code idle notifications no longer mark a session complete while its background agents are still working.",
-  "summary_zh": "Claude Code 的后台 Agent 仍在工作时，空闲通知不再误将会话标记为已完成。"
-}

--- a/changes/unreleased/20260817-release-notes-version-summary.json
+++ b/changes/unreleased/20260817-release-notes-version-summary.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Changed",
-  "scope": "release",
-  "summary_en": "GitHub Releases now lead with the exact version change summary and follow it with concise installation guidance.",
-  "summary_zh": "GitHub Release 现在会先展示对应版本的变更摘要，再附上精简安装说明。"
-}

--- a/changes/unreleased/control-center-visibility-invariants.json
+++ b/changes/unreleased/control-center-visibility-invariants.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "macos",
-  "summary_en": "Control Center presentation now has one focus-safe window owner, nonblocking appearance hydration, and a repeated cold-launch release gate.",
-  "summary_zh": "控制中心现由单一且焦点安全的窗口协调器展示，主题加载不再阻塞窗口，并新增重复冷启动发布门禁。"
-}

--- a/crates/petcore-cli/Cargo.toml
+++ b/crates/petcore-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-cli"
-version = "0.4.5"
+version = "0.4.6"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore-types/Cargo.toml
+++ b/crates/petcore-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-types"
-version = "0.4.5"
+version = "0.4.6"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore/Cargo.toml
+++ b/crates/petcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore"
-version = "0.4.5"
+version = "0.4.6"
 edition.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
## Summary

- prepare Agent Pet Companion `0.4.6` from the complete frozen three-fragment inventory
- synchronize PetCore, CLI, types, and Cargo lock identities at `0.4.6`
- consume the Control Center, GitHub Release notes, and Claude background-session fixes into the bilingual release changelog

## Impact

This patch release improves Control Center cold-launch reliability, presents version-specific GitHub Release summaries, and prevents Claude Code idle notifications from completing sessions while background agents are still working.

## Validation

- `python3 script/development_domains.py validate` (11 domains)
- `python3 script/tests/test_validation_tooling.py` (58 passed)
- `./script/validate_build_scripts_safety.sh --static-only`
- `python3 script/tests/test_release_distribution_contracts.py` (44 passed)
- `python3 script/validate_codex_plugin_version.py --base-ref v0.4.5`
- `cargo check --workspace --all-targets --locked`
- `./script/validate_pre_push.sh --base origin/main`
- `./script/changelog_fragments.py require-consumed`
- `./script/changelog_fragments.py policy --base-ref origin/main --release-preparation true`

## Development claim / 开发声明

- Domain: `release-control-plane`
- Claim: `control-plane`
- Base commit: `6800eb66f61f8ac4a67f395b30f83208349d4606`
- Release preparation: `yes`
- Focused validation:
  - `python3 script/tests/test_validation_tooling.py`
  - `./script/validate_build_scripts_safety.sh --static-only`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":2,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-17T11:43:29Z","train_conflict_resolutions":0} -->