### PR TITLE
Fix stale failure bubbles after session close

### DIFF
--- a/changes/unreleased/closed-failed-bubble-restart-87e069b.json
+++ b/changes/unreleased/closed-failed-bubble-restart-87e069b.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Fixed",
+  "scope": "overlay",
+  "summary_en": "Explicitly closed Agent sessions no longer restore stale failure bubbles when the pet or PetCore reopens.",
+  "summary_zh": "已明确关闭的 Agent 会话不会在宠物或 PetCore 重新打开后恢复陈旧的失败气泡。"
+}

--- a/crates/petcore/src/agent_state.rs
+++ b/crates/petcore/src/agent_state.rs
@@ -221,7 +221,8 @@ struct TimedCandidate<'a> {
 /// session instead of allowing older activity to reappear. A host
 /// `session_active` hint extends ordinary activity only through the configured
 /// session window; it is not durable proof that a connector session is still
-/// running. Waiting and failed attention states do not expire locally.
+/// running. Waiting and failed attention states do not expire locally, but an
+/// explicit host close/archive edge removes the closed session immediately.
 pub fn select_active_agent_state(
     behavior: &BehaviorSettings,
     candidates: &[SequencedAgentEvent],
@@ -243,7 +244,7 @@ pub fn select_active_agent_state_with_acknowledgements(
     latest_candidates_by_session(candidates, now)
         .into_values()
         .filter(|candidate| event_enabled(behavior, &candidate.candidate.event))
-        .filter(|candidate| !event_is_explicitly_closed_completion(&candidate.candidate.event))
+        .filter(|candidate| !candidate_is_explicitly_closed_session(candidate.candidate))
         .filter(|candidate| terminal_event_has_prior_activation(candidate))
         .filter(|candidate| {
             !candidate_is_acknowledged(candidate.candidate, acknowledged_session_activations)
@@ -276,7 +277,8 @@ pub fn select_active_agent_state_with_acknowledgements(
 /// and reappear when the next user activation/start event arrives. A completed
 /// session whose host explicitly reports `session_open = false` is already
 /// archived/closed and leaves the bubble immediately while remaining in audit
-/// history.
+/// history. The same explicit close also resolves a previously latched failure
+/// in that activity epoch instead of restoring it after PetCore restarts.
 pub fn select_display_agent_states(
     behavior: &BehaviorSettings,
     candidates: &[SequencedAgentEvent],
@@ -302,7 +304,7 @@ pub fn select_display_agent_states_with_acknowledgements(
     let mut visible = latest_candidates_by_session(candidates, now)
         .into_values()
         .filter(|candidate| event_enabled(behavior, &candidate.candidate.event))
-        .filter(|candidate| !event_is_explicitly_closed_completion(&candidate.candidate.event))
+        .filter(|candidate| !candidate_is_explicitly_closed_session(candidate.candidate))
         .filter(|candidate| terminal_event_has_prior_activation(candidate))
         .filter(|candidate| {
             !candidate_is_acknowledged(candidate.candidate, acknowledged_session_activations)
@@ -465,19 +467,36 @@ fn latest_candidates_by_session<'a>(
                         .is_none_or(|boundary| candidate_order(candidate) >= boundary)
                 })
                 .collect::<Vec<_>>();
-            // A host may publish Failed and then its normal idle/close tail.
-            // Keep the failure latched within that activity epoch; a later
-            // non-terminal event starts a new epoch and permits progression.
+            // A host may publish Failed and then its normal idle tail. Keep the
+            // failure latched within that activity epoch, except when a newer
+            // edge explicitly proves that the whole session was closed. A
+            // later non-terminal event starts a new epoch and permits normal
+            // progression.
             let latest_failed = current_epoch
                 .iter()
                 .filter(|candidate| candidate.candidate.event.event_type == AgentEventType::Failed)
+                .max_by_key(|candidate| candidate_order(candidate))
+                .copied();
+            let latest_explicit_close = current_epoch
+                .iter()
+                .filter(|candidate| {
+                    payload_explicitly_closes_session(&candidate.candidate.event.payload_json)
+                })
                 .max_by_key(|candidate| candidate_order(candidate))
                 .copied();
             let latest = current_epoch
                 .iter()
                 .max_by_key(|candidate| candidate_order(candidate))
                 .copied();
-            latest_failed.or(latest).map(|candidate| (key, candidate))
+            let selected = match (latest_failed, latest_explicit_close) {
+                (Some(failed), Some(closed))
+                    if candidate_order(&closed) >= candidate_order(&failed) =>
+                {
+                    Some(closed)
+                }
+                _ => latest_failed.or(latest),
+            };
+            selected.map(|candidate| (key, candidate))
         })
         .collect()
 }
@@ -520,16 +539,24 @@ fn terminal_event_has_prior_activation(candidate: &TimedCandidate<'_>) -> bool {
         || candidate.candidate.session_activated_at.is_some()
 }
 
-/// A successful completion remains useful in the return bubble only while the
-/// host still exposes a destination. An explicit close/archive edge is durable
-/// audit history, not an unavailable message the user must manually dismiss.
-fn event_is_explicitly_closed_completion(event: &AgentEvent) -> bool {
-    event.event_type == AgentEventType::Done
-        && event
-            .payload_json
-            .get("session_open")
-            .and_then(serde_json::Value::as_bool)
-            == Some(false)
+/// Completion and failure states remain useful only while the host still
+/// exposes their session. The storage projection attaches navigation from a
+/// later terminal edge to a latched failure; honor that explicit close as well
+/// as a close carried by the selected event itself. The immutable events remain
+/// available in audit history.
+fn candidate_is_explicitly_closed_session(candidate: &SequencedAgentEvent) -> bool {
+    payload_explicitly_closes_session(&candidate.event.payload_json)
+        || candidate
+            .latest_terminal_navigation_payload
+            .as_ref()
+            .is_some_and(payload_explicitly_closes_session)
+}
+
+fn payload_explicitly_closes_session(payload: &serde_json::Value) -> bool {
+    payload
+        .get("session_open")
+        .and_then(serde_json::Value::as_bool)
+        == Some(false)
 }
 
 fn active_state_from_candidate(

--- a/crates/petcore/tests/integration_d/agent_state_arbitration.rs
+++ b/crates/petcore/tests/integration_d/agent_state_arbitration.rs
@@ -3320,9 +3320,21 @@ fn active_waiting_and_compaction_starts_open_epochs_without_faking_user_activati
 }
 
 #[test]
-fn latched_failure_keeps_status_but_merges_later_terminal_navigation() {
-    let (_temp, state) = ready();
-    for (source, session_id, activation, failure, close, expected_open) in [
+fn explicit_close_removes_latched_failure_and_stays_closed_across_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let paths = AppPaths::new(temp.path().join("home"));
+    let state = CoreState::new(paths.clone());
+    state.ensure_ready().unwrap();
+
+    for (source, session_id, activation, failure, close, session_open) in [
+        (
+            "codex",
+            "019f5b0f-88ff-7413-8953-29de4ed0951c",
+            "UserPromptSubmit",
+            "app_server_activity",
+            "app_server_activity",
+            false,
+        ),
         (
             "claude_code",
             "claude-failed-navigation",
@@ -3393,39 +3405,67 @@ fn latched_failure_keeps_status_but_merges_later_terminal_navigation() {
                 "outcome": "session_closed",
                 "affects_activity": true,
                 "session_active": false,
-                "session_open": expected_open,
+                "session_open": session_open,
                 "session_surface": "cli_terminal",
                 "terminal_app": "terminal"
             }),
         );
     }
-    let snapshot = snapshot(&state);
-    for (session_id, expected_open) in [
-        ("claude-failed-navigation", true),
-        ("pi-failed-navigation", false),
-        ("opencode-failed-navigation", false),
-    ] {
-        let session = snapshot["active_agent_sessions"]
+
+    let assert_projection = |current: &Value| {
+        let session = current["active_agent_sessions"]
             .as_array()
             .unwrap()
             .iter()
-            .find(|session| session["session_id"] == projected_session_id(session_id))
-            .unwrap();
+            .find(|session| {
+                session["session_id"] == projected_session_id("claude-failed-navigation")
+            })
+            .expect("openable Claude session keeps its failed status");
         assert_eq!(session["official_status"], "blocked");
         assert_eq!(
             session["overlay_display"]["navigation"]["session_open"],
-            expected_open
+            true
         );
         assert_eq!(
             session["overlay_display"]["navigation"]["capability"],
-            if expected_open {
-                "agent_host"
-            } else {
-                "unavailable"
-            }
+            "agent_host"
         );
         assert_eq!(session["overlay_display"]["summary_kind"], "failed");
+
+        for session_id in [
+            "019f5b0f-88ff-7413-8953-29de4ed0951c",
+            "pi-failed-navigation",
+            "opencode-failed-navigation",
+        ] {
+            assert!(
+                current["active_agent_sessions"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .all(|session| session["session_id"] != projected_session_id(session_id)),
+                "explicitly closed failure reappeared for {session_id}"
+            );
+        }
+    };
+
+    let current = snapshot(&state);
+    assert_projection(&current);
+    for event_id in [
+        "019f5b0f-88ff-7413-8953-29de4ed0951c-close",
+        "pi-failed-navigation-close",
+        "opencode-failed-navigation-close",
+    ] {
+        assert!(current["recent_events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|event| event["id"] == projected_event_id(event_id)));
     }
+
+    drop(state);
+    let restarted = CoreState::new(paths);
+    restarted.ensure_ready().unwrap();
+    assert_projection(&snapshot(&restarted));
 }
 
 #[test]


### PR DESCRIPTION
## Development claim / 开发声明

- Domain: `release-control-plane`
- Claim: `engineering-speedup`
- Base commit: `87e069b74174d247a1e9b0ade6c56072a5191363`
- Release preparation: `no`
- Focused validation:
  - `python3 script/tests/test_validation_tooling.py`
  - `./script/validate_build_scripts_safety.sh --static-only`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":2,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-18T06:27:41Z","train_conflict_resolutions":0} -->