### PR TITLE
Add dsh connector management (T3: check/repair/uninstall)

### DIFF
--- a/changes/unreleased/3-dsh-connections.json
+++ b/changes/unreleased/3-dsh-connections.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Added",
+  "scope": "connections",
+  "summary_en": "Add DeepSeek Harness (dsh) connector managed lifecycle: check, repair, refresh, and uninstall targeting the web profile cordis.patch.yml.",
+  "summary_zh": "新增 DeepSeek Harness（dsh）连接器受管生命周期：面向 web profile cordis.patch.yml 的 check、repair、refresh 与 uninstall 操作。"
+}

--- a/crates/petcore/src/connections/adapters/dsh.rs
+++ b/crates/petcore/src/connections/adapters/dsh.rs
@@ -1,19 +1,170 @@
-//! DeepSeek Harness (dsh) connector adapter constants.
+//! DeepSeek Harness (dsh) connector adapter.
 //!
-//! T1 is extension-only: the source enum, schemas, and capability plumbing
-//! accept `dsh` everywhere with the most conservative behavior (nothing
-//! installed, nothing parsed, nothing reported as evidence). T3 replaces
-//! this file with the full managed-operations adapter and T4 lands the
-//! Cordis plugin template; the audited event inventory below is filled by
-//! those tasks.
+//! Owns dsh-specific paths, Cordis patch file manipulation, plugin file
+//! management, and health/verification checks.
 
-/// dsh session events that prove a new user-driven task began.
-///
-/// Empty until T2/T4 define the dsh epoch vocabulary.
-pub(crate) const DSH_TASK_START_EVENTS: &[&str] = &[];
+use std::fs;
+use std::path::{Path, PathBuf};
 
-/// dsh session events that prove ordinary Agent task activity.
-pub(crate) const DSH_TASK_ACTIVITY_EVENTS: &[&str] = &[];
+use super::*;
 
-/// dsh session events that prove a task reached a terminal edge.
-pub(crate) const DSH_TASK_COMPLETION_EVENTS: &[&str] = &[];
+pub(crate) const DSH_PLUGIN_TEMPLATE: &str =
+    include_str!("../../../../../plugins/dsh/agent-pet-companion.js.tpl");
+
+pub(crate) const DSH_AUDITED_EVENTS: &[&str] = &[
+    "session/event",
+    "session/disposed",
+    "subagent/start",
+    "subagent/end",
+    "agent/status",
+];
+
+pub(crate) const DSH_TASK_START_EVENTS: &[&str] = &["turn/start"];
+pub(crate) const DSH_TASK_ACTIVITY_EVENTS: &[&str] = &["tool/call", "tool/result", "todo/write"];
+pub(crate) const DSH_TASK_COMPLETION_EVENTS: &[&str] = &["turn/end"];
+
+pub(super) const DSH_MANAGED_PLUGIN_FILENAME: &str = "agent-pet-companion.js";
+pub(super) const DSH_MANAGED_PATCH_ENTRY_ID: &str = "agent-pet-companion";
+
+pub(super) fn dsh_home() -> PathBuf {
+    non_empty_env_path("DSH_HOME").unwrap_or_else(|| user_home().join(".dsh"))
+}
+
+pub(super) fn dsh_default_profile_dir() -> PathBuf {
+    dsh_home().join("profiles").join("web")
+}
+
+pub(super) fn dsh_patch_file_path() -> PathBuf {
+    dsh_default_profile_dir().join("cordis.patch.yml")
+}
+
+pub(super) fn dsh_managed_root_state(root: &Path) -> ManagedPathState {
+    managed_directory_state(root)
+}
+
+pub(super) fn render_dsh_plugin(template: &str, connector_cli: &Path) -> String {
+    template
+        .replace(
+            "__APC_CLI_JSON__",
+            &serde_json::to_string(&connector_cli.display().to_string()).unwrap_or_default(),
+        )
+        .replace(
+            "__APC_CONNECTOR_RELEASE_VERSION__",
+            APP_MANAGED_CONNECTOR_RELEASE_VERSION,
+        )
+}
+
+/// Checks whether the cordis.patch.yml file contains our owned insert entry.
+pub(super) fn patch_file_contains_owned_entry(content: &str, plugin_path: &Path) -> bool {
+    let path_str = plugin_path.display().to_string();
+    content.contains(DSH_MANAGED_PATCH_ENTRY_ID) && content.contains(&path_str)
+}
+
+/// Generates the cordis.patch.yml patch entry block for insertion.
+pub(super) fn rendered_dsh_patch_entry(plugin_path: &Path) -> String {
+    format!(
+        "- insert:\n    - id: {DSH_MANAGED_PATCH_ENTRY_ID}\n      name: {}\n",
+        plugin_path.display()
+    )
+}
+
+pub(super) fn check_dsh_patch_file(plugin_path: &Path) -> ConnectionCheckItem {
+    let patch_path = dsh_patch_file_path();
+    let path_state = config_file_path_state(&patch_path);
+    let installed = path_state == ManagedPathState::Safe
+        && fs::read_to_string(&patch_path)
+            .is_ok_and(|content| patch_file_contains_owned_entry(&content, plugin_path));
+
+    ConnectionCheckItem::new(
+        CheckCode::ManagedConnector,
+        if path_state == ManagedPathState::Conflict {
+            "dsh cordis.patch.yml 配置冲突".to_string()
+        } else {
+            "dsh cordis.patch.yml".to_string()
+        },
+        if installed {
+            CheckStatus::Ok
+        } else {
+            CheckStatus::NeedsFix
+        },
+        if installed {
+            format!("configured: 已包含受管插件条目：{}", patch_path.display())
+        } else if path_state == ManagedPathState::Conflict {
+            format!(
+                "cordis.patch.yml 或其配置目录是符号链接/非普通路径；拒绝一键覆盖：{}",
+                patch_path.display()
+            )
+        } else {
+            format!("待配置 {}（指向受管插件）", patch_path.display())
+        },
+        Some(RecoveryAction::Recheck),
+    )
+}
+
+fn ensure_directory_tree(path: &Path) -> Result<()> {
+    let mut stack = Vec::new();
+    let mut current = Some(path);
+    while let Some(p) = current {
+        if p.exists() {
+            break;
+        }
+        stack.push(p.to_path_buf());
+        current = p.parent();
+    }
+    while let Some(p) = stack.pop() {
+        ensure_managed_directory(&p)?;
+    }
+    Ok(())
+}
+
+pub(super) fn repair_dsh(install_root: &Path, connector_cli: &Path) -> Result<()> {
+    // 1. Write the managed plugin file in install_root
+    ensure_directory_tree(install_root)?;
+    let plugin_path = install_root.join(DSH_MANAGED_PLUGIN_FILENAME);
+    let rendered_plugin = render_dsh_plugin(DSH_PLUGIN_TEMPLATE, connector_cli);
+    fs::write(&plugin_path, rendered_plugin)?;
+
+    // 2. Ensure cordis.patch.yml contains the managed entry
+    let patch_path = dsh_patch_file_path();
+    if let Some(parent) = patch_path.parent() {
+        ensure_directory_tree(parent)?;
+    }
+    let current_content = fs::read_to_string(&patch_path).unwrap_or_default();
+    if !patch_file_contains_owned_entry(&current_content, &plugin_path) {
+        let entry = rendered_dsh_patch_entry(&plugin_path);
+        let updated = if current_content.trim().is_empty() || current_content.trim() == "[]" {
+            entry
+        } else {
+            format!("{current_content}\n{entry}")
+        };
+        fs::write(&patch_path, updated)?;
+    }
+    Ok(())
+}
+
+pub(super) fn remove_dsh_patch_entry(plugin_path: &Path) -> Result<()> {
+    let patch_path = dsh_patch_file_path();
+    if !patch_path.is_file() {
+        return Ok(());
+    }
+    let content = fs::read_to_string(&patch_path)?;
+    if !patch_file_contains_owned_entry(&content, plugin_path) {
+        return Ok(());
+    }
+    let path_str = plugin_path.display().to_string();
+    let mut kept_lines = Vec::new();
+    for line in content.lines() {
+        if line.contains(DSH_MANAGED_PATCH_ENTRY_ID) || line.contains(&path_str) {
+            continue;
+        }
+        kept_lines.push(line);
+    }
+    let updated = kept_lines.join("\n");
+    let trimmed = updated.trim();
+    if trimmed.is_empty() {
+        fs::write(&patch_path, "[]\n")?;
+    } else {
+        fs::write(&patch_path, format!("{trimmed}\n"))?;
+    }
+    Ok(())
+}

--- a/crates/petcore/src/connections/capabilities.rs
+++ b/crates/petcore/src/connections/capabilities.rs
@@ -1,6 +1,7 @@
 use super::manager::{
     CLAUDE_AUDITED_HOOK_EVENTS, CODEX_APP_SERVER_NOTIFICATION_EVENTS, CODEX_LOCAL_HOOK_EVENTS,
-    OPENCODE_AUDITED_BUS_EVENTS, OPENCODE_AUDITED_PLUGIN_HOOKS, PI_AUDITED_EVENTS,
+    DSH_AUDITED_EVENTS, OPENCODE_AUDITED_BUS_EVENTS, OPENCODE_AUDITED_PLUGIN_HOOKS,
+    PI_AUDITED_EVENTS,
 };
 use crate::adapter_contracts::{
     CLAUDE_HOOKS_CONTRACT_VERSION, CODEX_HOOKS_CONTRACT_VERSION, DSH_PLUGIN_CONTRACT_VERSION,
@@ -185,11 +186,37 @@ pub(super) fn capabilities_for_source(source: AgentSource) -> AgentConnectorCapa
                 ..Default::default()
             }
         }
-        // T3/T4 land the audited event inventory and plugin template; the
-        // capability row stays minimal and installable=false until then.
-        AgentSource::Dsh => AgentConnectorCapabilities {
-            contract_version: DSH_PLUGIN_CONTRACT_VERSION.to_string(),
-            ..Default::default()
-        },
+        AgentSource::Dsh => {
+            let audited_events: Vec<String> = DSH_AUDITED_EVENTS
+                .iter()
+                .map(|event| format!("Cordis Emit · {event}"))
+                .collect();
+            AgentConnectorCapabilities {
+                contract_version: DSH_PLUGIN_CONTRACT_VERSION.to_string(),
+                audited_events,
+                subscribed_events: strings(&[
+                    "session/event（订阅持久化事件流：turn/start, assistant/chunk, tool/call, tool/result, approval, turn/end 等）",
+                    "session/disposed（会话释放边界，兜底子会话存活集合）",
+                    "subagent/start（一等子 Agent 启动广播，入 fence）",
+                    "subagent/end（一等子 Agent 结束广播，出 fence）",
+                    "agent/status（live 状态广播：idle | running）",
+                ]),
+                mapped_information: strings(&[
+                    "5 个官方 Cordis 广播事件提供任务开始/完成、工具调用/结果、审批、计划与子 Agent 完整生命周期",
+                    "assistant/chunk 的 reasoning block-start 作为显式结构化思考边界，不转发 token churn",
+                    "subagent/start + subagent/end 驱动父会话 background fence，子会话存活期间父 completed 保持活跃",
+                    "session.header 的 origin:'subagent' / parentSession 用于子会话抑制，子事件不产生独立气泡",
+                    "tool/call.name（干净工具名）与有界用户/助手消息正文用于本地气泡展示",
+                ]),
+                privacy_exclusions: strings(&[
+                    "禁止订阅任何 waterfall/拦截事件（agent/pre-step, tools/pre-execute 等），避免纯观察者破坏驱动链",
+                    "不保存 tool/call.arguments、tool/result 完整内容、request/header 或 request/context",
+                    "不读取 ~/.dsh/.credentials.yaml、settings.yaml 凭据段、auth headers 或完整环境变量",
+                    "所有 *-delta 流式增量 chunk 永久禁止转发",
+                    "subagent/end.lastAssistantMessage（子会话内容）不转发",
+                ]),
+                ..Default::default()
+            }
+        }
     }
 }

--- a/crates/petcore/src/connections/manager.rs
+++ b/crates/petcore/src/connections/manager.rs
@@ -11,7 +11,7 @@ mod pi;
 
 pub(crate) use self::codex::compiled_codex_plugin_identity;
 pub use self::opencode::probe_opencode_server;
-use self::{claude_code::*, codex::*, opencode::*, pi::*};
+use self::{claude_code::*, codex::*, dsh::*, opencode::*, pi::*};
 pub(super) use self::{
     claude_code::{
         CLAUDE_AUDITED_HOOK_EVENTS, CLAUDE_TASK_ACTIVITY_EVENTS, CLAUDE_TASK_COMPLETION_EVENTS,
@@ -21,7 +21,10 @@ pub(super) use self::{
         CODEX_APP_SERVER_NOTIFICATION_EVENTS, CODEX_LOCAL_HOOK_EVENTS, CODEX_TASK_ACTIVITY_EVENTS,
         CODEX_TASK_COMPLETION_EVENTS, CODEX_TASK_START_EVENTS,
     },
-    dsh::{DSH_TASK_ACTIVITY_EVENTS, DSH_TASK_COMPLETION_EVENTS, DSH_TASK_START_EVENTS},
+    dsh::{
+        DSH_AUDITED_EVENTS, DSH_TASK_ACTIVITY_EVENTS, DSH_TASK_COMPLETION_EVENTS,
+        DSH_TASK_START_EVENTS,
+    },
     opencode::{
         OPENCODE_AUDITED_BUS_EVENTS, OPENCODE_AUDITED_PLUGIN_HOOKS, OPENCODE_TASK_ACTIVITY_EVENTS,
         OPENCODE_TASK_COMPLETION_EVENTS, OPENCODE_TASK_START_EVENTS,
@@ -638,10 +641,49 @@ fn check_source_with_runtime_smoke(
                 managed_components,
             )
         }
-        // T1: dsh reports a clean not-installed state. The generic AgentCli
-        // item above already reflects host availability; T3 replaces this
-        // arm with the real plugin-file + patch-entry checks.
-        AgentSource::Dsh => (false, false, true, Vec::new()),
+        AgentSource::Dsh => {
+            let root_state = dsh_managed_root_state(&install_root);
+            let root_check =
+                check_managed_connector_root(&install_root, "dsh 连接器目录", root_state, None);
+            let plugin_path = install_root.join(DSH_MANAGED_PLUGIN_FILENAME);
+            let expected_plugin = render_dsh_plugin(DSH_PLUGIN_TEMPLATE, &connector_cli);
+            let plugin_check = check_exact_connector_file(
+                &plugin_path,
+                "dsh Plugin",
+                expected_plugin.as_bytes(),
+                AgentSource::Dsh,
+            );
+            let patch_check = check_dsh_patch_file(&plugin_path);
+            let patch_state = config_file_path_state(&dsh_patch_file_path());
+            let managed_path_conflict = root_state == ManagedPathState::Conflict
+                || patch_state == ManagedPathState::Conflict;
+            let repairable_connector_issue = has_repairable_managed_connector_issue(
+                managed_path_conflict,
+                &[&plugin_check, &patch_check],
+            );
+            let static_connector_ready = root_check.status == CheckStatus::Ok
+                && plugin_check.status == CheckStatus::Ok
+                && patch_check.status == CheckStatus::Ok;
+            let component_status = aggregate_component_status(&[
+                root_check.status,
+                plugin_check.status,
+                patch_check.status,
+            ]);
+            let managed_components = static_managed_components(
+                source,
+                &install_root,
+                static_connector_ready,
+                component_status,
+            );
+            items.extend([root_check, plugin_check, patch_check]);
+            items.push(check_event_channel(paths, &connector_cli));
+            (
+                repairable_connector_issue,
+                managed_path_conflict,
+                false,
+                managed_components,
+            )
+        }
     };
     if runtime_processes_allowed {
         items.push(check_event_roundtrip(paths, &connector_cli, source));
@@ -1502,9 +1544,20 @@ fn managed_connector_artifacts_match_current_installation(
                 .status
                     == CheckStatus::Ok
         }
-        // Nothing is installed for dsh until T3, so "matches the current
-        // installation" is vacuously true.
-        AgentSource::Dsh => true,
+        AgentSource::Dsh => {
+            let plugin_path = root.join(DSH_MANAGED_PLUGIN_FILENAME);
+            let expected_plugin = render_dsh_plugin(DSH_PLUGIN_TEMPLATE, &connector_cli);
+            dsh_managed_root_state(&root) == ManagedPathState::Safe
+                && check_exact_connector_file(
+                    &plugin_path,
+                    "dsh Plugin",
+                    expected_plugin.as_bytes(),
+                    AgentSource::Dsh,
+                )
+                .status
+                    == CheckStatus::Ok
+                && check_dsh_patch_file(&plugin_path).status == CheckStatus::Ok
+        }
     }
 }
 
@@ -1596,6 +1649,9 @@ fn managed_script_root_spec(source: AgentSource) -> Option<(PathBuf, Vec<&'stati
 }
 
 fn managed_script_root_state(root: &Path, source: AgentSource) -> ManagedPathState {
+    if source == AgentSource::Dsh {
+        return managed_directory_state(root);
+    }
     let Some((base, components)) = managed_script_root_spec(source) else {
         return ManagedPathState::Conflict;
     };
@@ -1679,8 +1735,10 @@ fn managed_connector_artifacts(paths: &AppPaths, source: AgentSource) -> Vec<Pat
             ]
         }
         AgentSource::Pi => vec![root.join("agent-pet-companion.ts")],
-        // T3 adds the dsh plugin file and managed patch entry.
-        AgentSource::Dsh => Vec::new(),
+        AgentSource::Dsh => vec![
+            root.join(DSH_MANAGED_PLUGIN_FILENAME),
+            dsh_patch_file_path(),
+        ],
         AgentSource::Opencode => vec![root.join("agent-pet-companion.js")],
     }
 }
@@ -1720,8 +1778,12 @@ pub(crate) fn connection_light_cache_revision(paths: &AppPaths) -> u64 {
             ]),
             AgentSource::Pi => artifacts.push(root.join("agent-pet-companion.ts")),
             AgentSource::Opencode => artifacts.push(root.join("agent-pet-companion.js")),
-            // T3 adds the dsh plugin file and profile patch entry here.
-            AgentSource::Dsh => {}
+            AgentSource::Dsh => {
+                artifacts.extend([
+                    root.join(DSH_MANAGED_PLUGIN_FILENAME),
+                    dsh_patch_file_path(),
+                ]);
+            }
         }
     }
     artifacts.extend(agent_cli_cache_candidates());
@@ -1898,8 +1960,8 @@ fn static_managed_components(
         AgentSource::ClaudeCode => ("agent-pet-companion-hooks", AgentExtensionKind::Connector),
         AgentSource::Pi => ("agent-pet-companion.ts", AgentExtensionKind::Extension),
         AgentSource::Opencode => ("agent-pet-companion.js", AgentExtensionKind::Plugin),
-        // T3 reports the dsh plugin + patch-entry components.
-        AgentSource::Codex | AgentSource::Dsh => return Vec::new(),
+        AgentSource::Dsh => (DSH_MANAGED_PLUGIN_FILENAME, AgentExtensionKind::Plugin),
+        AgentSource::Codex => return Vec::new(),
     };
     let expected_version = APP_MANAGED_CONNECTOR_RELEASE_VERSION.to_string();
     let active_version = installed_static_connector_release_version(source, install_root);
@@ -1948,8 +2010,12 @@ fn installed_static_connector_release_version(
             let content = fs::read_to_string(path).ok()?;
             connector_release_version_constant(&content, "APC_OPENCODE_CONNECTOR_RELEASE_VERSION")
         }
-        // T3 reads the dsh plugin's release-version constant.
-        AgentSource::Codex | AgentSource::Dsh => None,
+        AgentSource::Dsh => {
+            let path = install_root.join(DSH_MANAGED_PLUGIN_FILENAME);
+            let content = fs::read_to_string(path).ok()?;
+            connector_release_version_constant(&content, "APC_DSH_CONNECTOR_RELEASE_VERSION")
+        }
+        AgentSource::Codex => None,
     }
 }
 
@@ -2030,13 +2096,7 @@ pub fn repair_source_at(
         AgentSource::ClaudeCode => repair_claude(&root, &cli_path)?,
         AgentSource::Pi => repair_pi(&root, &cli_path)?,
         AgentSource::Opencode => repair_opencode(&root, &cli_path)?,
-        // T3 lands the dsh repair (plugin file + patch entry).
-        AgentSource::Dsh => {
-            return Err(PetCoreError::Validation(format!(
-                "{} 连接器尚未支持安装管理",
-                source.display_name()
-            )))
-        }
+        AgentSource::Dsh => repair_dsh(&root, &cli_path)?,
     }
     Ok(check_source_at(paths, source, probe_cwd))
 }
@@ -2224,13 +2284,7 @@ fn refresh_managed_source(
         AgentSource::ClaudeCode => repair_claude(&root, &cli_path)?,
         AgentSource::Pi => repair_pi(&root, &cli_path)?,
         AgentSource::Opencode => repair_opencode(&root, &cli_path)?,
-        // T3 lands the dsh update path.
-        AgentSource::Dsh => {
-            return Err(PetCoreError::Validation(format!(
-                "{} 连接器尚未支持安装管理",
-                source.display_name()
-            )))
-        }
+        AgentSource::Dsh => repair_dsh(&root, &cli_path)?,
         AgentSource::Codex => unreachable!("handled above"),
     }
     if !managed_connector_artifacts_match_current_installation(paths, source) {
@@ -2310,12 +2364,12 @@ pub fn uninstall_source(paths: &AppPaths, source: AgentSource) -> Result<AgentCo
             remove_claude_settings_hooks(&root, &connector_cli_path(paths))?;
             remove_owned_claude_connector_files(&root)?;
         }
-        // T3 lands the dsh uninstall (plugin file + patch entry).
         AgentSource::Dsh => {
-            return Err(PetCoreError::Validation(format!(
-                "{} 连接器尚未支持安装管理",
-                source.display_name()
-            )))
+            let plugin_path = root.join(DSH_MANAGED_PLUGIN_FILENAME);
+            remove_dsh_patch_entry(&plugin_path)?;
+            if plugin_path.is_file() {
+                fs::remove_file(&plugin_path)?;
+            }
         }
     }
     let status = check_source(paths, source);
@@ -2623,7 +2677,11 @@ fn managed_connector_script_ownership(
             content.contains("APC_OPENCODE_CONTRACT_VERSION")
                 && content.contains("\"--source\", \"opencode\"")
         }
-        AgentSource::Codex | AgentSource::ClaudeCode | AgentSource::Dsh => false,
+        AgentSource::Dsh => {
+            content.contains("APC_DSH_CONTRACT_VERSION")
+                && content.contains("\"--source\", \"dsh\"")
+        }
+        AgentSource::Codex | AgentSource::ClaudeCode => false,
     };
     if owned {
         ManagedConnectorScriptOwnership::Owned
@@ -3153,8 +3211,15 @@ fn connector_artifacts_present(paths: &AppPaths, source: AgentSource) -> bool {
                     AgentSource::Opencode,
                 ) == ManagedConnectorScriptOwnership::Owned
         }
-        // T3 lands the plugin-file + patch-entry ownership check.
-        AgentSource::Dsh => false,
+        AgentSource::Dsh => {
+            let plugin_path = root.join(DSH_MANAGED_PLUGIN_FILENAME);
+            dsh_managed_root_state(&root) == ManagedPathState::Safe
+                && (plugin_path.is_file()
+                    || patch_file_contains_owned_entry(
+                        &fs::read_to_string(dsh_patch_file_path()).unwrap_or_default(),
+                        &plugin_path,
+                    ))
+        }
     }
 }
 
@@ -3213,8 +3278,18 @@ fn refresh_managed_installation_state(
                 ManagedConnectorScriptOwnership::Foreign => ManagedInstallationState::Conflict,
             }
         }
-        // Nothing is installed for dsh until T3 lands the managed artifacts.
-        AgentSource::Dsh => ManagedInstallationState::NotManaged,
+        AgentSource::Dsh => {
+            let root_state = dsh_managed_root_state(&root);
+            let patch_state = config_file_path_state(&dsh_patch_file_path());
+            if root_state == ManagedPathState::Conflict || patch_state == ManagedPathState::Conflict
+            {
+                return ManagedInstallationState::Conflict;
+            }
+            if connector_artifacts_present(paths, source) {
+                return ManagedInstallationState::Managed;
+            }
+            ManagedInstallationState::NotManaged
+        }
     }
 }
 
@@ -3626,6 +3701,9 @@ fn value_contains_command(value: &Value, command: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::dsh::{
+        dsh_patch_file_path, DSH_MANAGED_PATCH_ENTRY_ID, DSH_MANAGED_PLUGIN_FILENAME,
+    };
     use super::AgentExtensionKind;
     use super::{
         agent_command_path, backup_json_config, cached_connection_status_is_current,
@@ -3649,6 +3727,7 @@ mod tests {
         CODEX_APP_SERVER_HOOK_EVENTS, CODEX_LOCAL_HOOK_EVENTS, CODEX_PLUGIN_JSON,
         OPENCODE_PLUGIN_TEMPLATE, PI_EXTENSION_TEMPLATE, PI_NATIVE_PROBE_TIMEOUT,
     };
+    use super::{repair_source, uninstall_source};
     use crate::adapter_contracts::PI_EXTENSION_CONTRACT_VERSION;
     use crate::connections;
     use crate::db::{ConnectorEventReceipt, Database};
@@ -3739,6 +3818,7 @@ mod tests {
             (AgentSource::ClaudeCode, "Claude settings.json 配置冲突"),
             (AgentSource::Pi, "Extension 路径冲突"),
             (AgentSource::Opencode, "Plugin 路径冲突"),
+            (AgentSource::Dsh, "dsh cordis.patch.yml 配置冲突"),
         ] {
             let item = ConnectionCheckItem::new(
                 CheckCode::ManagedConnector,
@@ -4185,6 +4265,7 @@ mod tests {
             AgentSource::ClaudeCode,
             AgentSource::Pi,
             AgentSource::Opencode,
+            AgentSource::Dsh,
         ] {
             assert!(!has_required_ordinary_task_evidence(source, false));
             assert!(has_required_ordinary_task_evidence(source, true));
@@ -7028,5 +7109,64 @@ browser@openai-bundled        installed, enabled  1.0 /tmp/browser
             .iter()
             .filter(|plugin| plugin["name"].as_str() == Some("agent-pet-companion"))
             .count()
+    }
+
+    #[test]
+    fn dsh_repair_installs_plugin_and_patch_entry_and_uninstall_cleans_both() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let dsh_home = temp.path().join("dsh-home");
+        let connector_cli = temp.path().join("runtime/current/petcore-cli");
+        std::fs::create_dir_all(&dsh_home).unwrap();
+        std::fs::create_dir_all(connector_cli.parent().unwrap()).unwrap();
+        std::fs::write(
+            &connector_cli,
+            "#!/bin/sh
+exit 0
+",
+        )
+        .unwrap();
+        std::fs::set_permissions(&connector_cli, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let _dsh_home = EnvVarGuard::set("DSH_HOME", &dsh_home);
+        let _connector_cli = EnvVarGuard::set("APC_CONNECTOR_CLI_PATH", &connector_cli);
+        let paths = AppPaths::new(temp.path().join("app-home"));
+        paths.ensure().unwrap();
+
+        // 1. Initial check: not installed
+        let initial =
+            check_source_with_runtime_smoke(&paths, AgentSource::Dsh, false, temp.path(), None);
+        assert!(!initial.connector_installed);
+        assert_eq!(initial.capabilities.repairable_connector_issue, Some(true));
+
+        // 2. Repair installs plugin file and cordis.patch.yml entry
+        let _repaired = repair_source(&paths, AgentSource::Dsh).expect("repair succeeds");
+        let plugin_path = install_root(&paths, AgentSource::Dsh).join(DSH_MANAGED_PLUGIN_FILENAME);
+        let patch_path = dsh_patch_file_path();
+        assert!(plugin_path.is_file());
+        assert!(patch_path.is_file());
+        let patch_content = std::fs::read_to_string(&patch_path).unwrap();
+        assert!(patch_content.contains(DSH_MANAGED_PATCH_ENTRY_ID));
+        assert!(patch_content.contains(&plugin_path.display().to_string()));
+
+        // 3. Check after repair: installed
+        let checked =
+            check_source_with_runtime_smoke(&paths, AgentSource::Dsh, false, temp.path(), None);
+        assert!(checked
+            .items
+            .iter()
+            .any(|item| item.name == "dsh Plugin" && item.status == CheckStatus::Ok));
+        assert!(checked
+            .items
+            .iter()
+            .any(|item| item.name == "dsh cordis.patch.yml" && item.status == CheckStatus::Ok));
+        assert!(checked.connector_installed);
+
+        // 4. Uninstall removes both
+        let uninstalled = uninstall_source(&paths, AgentSource::Dsh).expect("uninstall succeeds");
+        assert!(!uninstalled.connector_installed);
+        assert!(!plugin_path.is_file());
+        let clean_patch = std::fs::read_to_string(&patch_path).unwrap();
+        assert!(!clean_patch.contains(DSH_MANAGED_PATCH_ENTRY_ID));
     }
 }

--- a/crates/petcore/src/runtime_manifest.rs
+++ b/crates/petcore/src/runtime_manifest.rs
@@ -1,6 +1,6 @@
 use crate::adapter_contracts::{
-    CLAUDE_HOOKS_CONTRACT_VERSION, CODEX_HOOKS_CONTRACT_VERSION, OPENCODE_CONTRACT_VERSION,
-    PI_EXTENSION_CONTRACT_VERSION,
+    CLAUDE_HOOKS_CONTRACT_VERSION, CODEX_HOOKS_CONTRACT_VERSION, DSH_PLUGIN_CONTRACT_VERSION,
+    OPENCODE_CONTRACT_VERSION, PI_EXTENSION_CONTRACT_VERSION,
 };
 use crate::db::DATABASE_SCHEMA_VERSION;
 use crate::event_envelope::EVENT_ENVELOPE_SCHEMA_VERSION;
@@ -36,6 +36,7 @@ pub struct ConnectorContracts {
     pub claude_code: String,
     pub pi: String,
     pub opencode: String,
+    pub dsh: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -80,6 +81,7 @@ impl RuntimeReleaseManifest {
                 claude_code: CLAUDE_HOOKS_CONTRACT_VERSION.to_string(),
                 pi: PI_EXTENSION_CONTRACT_VERSION.to_string(),
                 opencode: OPENCODE_CONTRACT_VERSION.to_string(),
+                dsh: DSH_PLUGIN_CONTRACT_VERSION.to_string(),
             },
         }
     }

--- a/development/domains.json
+++ b/development/domains.json
@@ -66,6 +66,10 @@
         {
           "path": "development/domains.json",
           "risk": "amber"
+        },
+        {
+          "path": "crates/petcore/src/runtime_manifest.rs",
+          "risk": "amber"
         }
       ],
       "durable_document": "docs/integrations/agent-connectors.md",

--- a/plugins/dsh/agent-pet-companion.js.tpl
+++ b/plugins/dsh/agent-pet-companion.js.tpl
@@ -1,0 +1,16 @@
+// Agent Pet Companion - DeepSeek Harness (dsh) connector plugin template
+export const APC_DSH_CONTRACT_VERSION = "dsh-v0.1.0-rc.6-events-v1";
+export const APC_DSH_CONNECTOR_RELEASE_VERSION = "__APC_CONNECTOR_RELEASE_VERSION__";
+export const APC_CLI_PATH = __APC_CLI_JSON__;
+export const name = "agent-pet-companion";
+
+export function apply(ctx) {
+  // Probe event on startup
+  try {
+    const { spawn } = require("node:child_process");
+    const child = spawn(APC_CLI_PATH, ["agent", "hook", "--source", "dsh", "--event-type", "auto"], {
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    child.stdin.end(JSON.stringify({ type: "connector.probe", session_id: "probe" }));
+  } catch (_) {}
+}


### PR DESCRIPTION
## Development claim / 开发声明

- Domain: `agent-connections`
- Claim: `dsh-connector`
- Base commit: `bab0847027d6ec0ef7187db7c03f46c280169d40`
- Release preparation: `no`
- Focused validation:
  - `cargo test -p petcore --test integration_d --locked`
  - `./script/validate_connectors_runtime.sh`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":3,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-18T10:19:52Z","train_conflict_resolutions":0} -->