### PR TITLE
Add dsh App-side runtime manifest (T5)

### DIFF
--- a/apps/macos/Sources/AgentPetCompanion/App/RuntimeReleaseManifest.swift
+++ b/apps/macos/Sources/AgentPetCompanion/App/RuntimeReleaseManifest.swift
@@ -8,16 +8,18 @@ struct RuntimeConnectorContracts: Codable, Equatable, Sendable {
     let claudeCode: String
     let pi: String
     let opencode: String
+    let dsh: String
 
     enum CodingKeys: String, CodingKey, CaseIterable {
         case codex
         case claudeCode = "claude_code"
         case pi
         case opencode
+        case dsh
     }
 
     var allArePresent: Bool {
-        [codex, claudeCode, pi, opencode].allSatisfy {
+        [codex, claudeCode, pi, opencode, dsh].allSatisfy {
             !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
     }
@@ -204,7 +206,8 @@ struct RuntimeReleaseManifest: Codable, Equatable, Sendable {
         codex: "codex-hooks-2026-07-17-schema-v6",
         claudeCode: "claude-hooks-2026-07-17-activity-v5",
         pi: "pi-extension-0.80.10-activity-v7",
-        opencode: "opencode-v1.18.0-activity-v8"
+        opencode: "opencode-v1.18.0-activity-v8",
+        dsh: "dsh-v0.1.0-rc.6-events-v1"
     )
 
     private static let publishedV1ReleaseIdentities = [

--- a/apps/macos/Tests/AgentPetCompanionTests/InitialAppearanceBootstrapTests.swift
+++ b/apps/macos/Tests/AgentPetCompanionTests/InitialAppearanceBootstrapTests.swift
@@ -731,7 +731,8 @@ struct InitialAppearanceBootstrapTests {
                 codex: "codex-hooks.v1",
                 claudeCode: "claude-hooks.v1",
                 pi: "pi-extension.v1",
-                opencode: "opencode-plugin.v1"
+                opencode: "opencode-plugin.v1",
+                dsh: "dsh-plugin.v1"
             )
         )
     }

--- a/apps/macos/Tests/AgentPetCompanionTests/PetCoreProcessManagerTests.swift
+++ b/apps/macos/Tests/AgentPetCompanionTests/PetCoreProcessManagerTests.swift
@@ -2023,7 +2023,8 @@ struct PetCoreProcessManagerTests {
                 codex: codexContract,
                 claudeCode: "claude-hooks.v1",
                 pi: "pi-extension.v1",
-                opencode: "opencode-plugin.v1"
+                opencode: "opencode-plugin.v1",
+                dsh: "dsh-plugin.v1"
             )
         )
     }
@@ -2062,7 +2063,8 @@ struct PetCoreProcessManagerTests {
                 codex: "codex-hooks-2026-07-17-schema-v6",
                 claudeCode: "claude-hooks-2026-07-17-activity-v5",
                 pi: "pi-extension-0.80.10-activity-v7",
-                opencode: "opencode-v1.18.0-activity-v8"
+                opencode: "opencode-v1.18.0-activity-v8",
+                dsh: "dsh-v0.1.0-rc.6-events-v1"
             )
         )
     }

--- a/apps/macos/Tests/AgentPetCompanionTests/ProductConvergenceTests.swift
+++ b/apps/macos/Tests/AgentPetCompanionTests/ProductConvergenceTests.swift
@@ -794,7 +794,8 @@ struct ProductConvergenceTests {
                 codex: "codex-hooks.v1",
                 claudeCode: "claude-hooks.v1",
                 pi: "pi-extension.v1",
-                opencode: "opencode-plugin.v1"
+                opencode: "opencode-plugin.v1",
+                dsh: "dsh-plugin.v1"
             )
         )
     }

--- a/changes/unreleased/5-dsh-app-surface.json
+++ b/changes/unreleased/5-dsh-app-surface.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Added",
+  "scope": "connections",
+  "summary_en": "Add DeepSeek Harness (dsh) to App-side runtime manifest and Agent Connections UI surfaces.",
+  "summary_zh": "在 App 端运行时清单与 Agent 连接设置页面中接入 DeepSeek Harness（dsh）。"
+}

--- a/development/domains.json
+++ b/development/domains.json
@@ -70,6 +70,10 @@
         {
           "path": "crates/petcore/src/runtime_manifest.rs",
           "risk": "amber"
+        },
+        {
+          "path": "apps/macos/Sources/AgentPetCompanion/App/RuntimeReleaseManifest.swift",
+          "risk": "amber"
         }
       ],
       "durable_document": "docs/integrations/agent-connectors.md",


### PR DESCRIPTION
## Development claim / 开发声明

- Domain: `agent-connections`
- Claim: `dsh-connector`
- Base commit: `113afbdc3cbecfad789e920c837aa54ae726ba03`
- Release preparation: `no`
- Focused validation:
  - `cargo test -p petcore --test integration_d --locked`
  - `./script/validate_connectors_runtime.sh`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":3,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-18T11:17:10Z","train_conflict_resolutions":0} -->