### PR TITLE
Add dsh E2E integration tests (T6)

### DIFF
--- a/changes/unreleased/6-dsh-e2e.json
+++ b/changes/unreleased/6-dsh-e2e.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Added",
+  "scope": "connections",
+  "summary_en": "Add end-to-end integration tests for DeepSeek Harness (dsh) verifying contract fixtures, bounds, and privacy enforcement.",
+  "summary_zh": "新增 DeepSeek Harness（dsh）端到端集成测试，验证契约测试用例、字段有界性与隐私约束。"
+}

--- a/crates/petcore/src/adapter_contracts.rs
+++ b/crates/petcore/src/adapter_contracts.rs
@@ -291,7 +291,10 @@ fn parse_dsh(source: AgentSource, input: &Value) -> Result<Option<ContractEvent>
             // Only the explicit reasoning block boundary is a legal thinking
             // edge; every delta, usage, finish, and non-reasoning block-start
             // is ignored (fail-open).
-            let block_type = string_at(input, &[&["chunk", "blockType"]]);
+            let block_type = string_at(
+                input,
+                &[&["chunk", "blockType"], &["data", "chunk", "blockType"]],
+            );
             if block_type.as_deref() != Some("reasoning") {
                 return Ok(None);
             }

--- a/crates/petcore/tests/integration_d/connector_contracts.rs
+++ b/crates/petcore/tests/integration_d/connector_contracts.rs
@@ -1467,8 +1467,7 @@ fn dsh_contract_fixtures_parse_authoritatively_with_bounds_and_privacy() {
     assert!(privacy_tool
         .activity_content
         .as_deref()
-        .map_or(true, |c| !c.contains("credentials")
-            && !c.contains("rm -rf")));
+        .is_none_or(|c| !c.contains("credentials") && !c.contains("rm -rf")));
 
     // subagent/end is not an activity-driving event (subagent lifecycle stays in plugin fence)
     assert!(parse_contract_event(

--- a/crates/petcore/tests/integration_d/connector_contracts.rs
+++ b/crates/petcore/tests/integration_d/connector_contracts.rs
@@ -1405,3 +1405,76 @@ fn every_cli_connector_exposes_display_and_navigation_lifecycle_fields() {
     assert_eq!(claude_closed.outcome.as_deref(), Some("session_closed"));
     assert_eq!(claude_closed.session_open, Some(true));
 }
+
+#[test]
+fn dsh_contract_fixtures_parse_authoritatively_with_bounds_and_privacy() {
+    // 1. turn-end-completed -> Done / completed / inactive
+    let completed = parsed(AgentSource::Dsh, "dsh-v0.1.0-rc.6/turn-end-completed.json");
+    assert_eq!(completed.kind, AgentEventType::Done);
+    assert_eq!(completed.outcome.as_deref(), Some("completed"));
+    assert!(!completed.session_active);
+
+    // 2. turn-end-error -> Failed / llm_failure_TRANSPORT (closed code, message not leaked)
+    let error = parsed(AgentSource::Dsh, "dsh-v0.1.0-rc.6/turn-end-error.json");
+    assert_eq!(error.kind, AgentEventType::Failed);
+    assert_eq!(error.outcome.as_deref(), Some("llm_failure_TRANSPORT"));
+    assert!(!error.session_active);
+
+    // 3. block-start-reasoning -> Thinking / reasoning_started / active
+    let thinking = parsed(
+        AgentSource::Dsh,
+        "dsh-v0.1.0-rc.6/block-start-reasoning.json",
+    );
+    assert_eq!(thinking.kind, AgentEventType::Thinking);
+    assert_eq!(thinking.outcome.as_deref(), Some("reasoning_started"));
+    assert!(thinking.session_active);
+
+    // 4. tool-result-failure -> Tool / tool_failure_ENOENT / active (recoverable)
+    let tool_fail = parsed(AgentSource::Dsh, "dsh-v0.1.0-rc.6/tool-result-failure.json");
+    assert_eq!(tool_fail.kind, AgentEventType::Tool);
+    assert_eq!(tool_fail.outcome.as_deref(), Some("tool_failure_ENOENT"));
+    assert!(tool_fail.session_active);
+
+    // 5. approval-decided -> Start / approval_decided_allowed-once
+    let approval = parsed(AgentSource::Dsh, "dsh-v0.1.0-rc.6/approval-decided.json");
+    assert_eq!(approval.kind, AgentEventType::Start);
+    assert_eq!(
+        approval.outcome.as_deref(),
+        Some("approval_decided_allowed-once")
+    );
+
+    // 6. Negative fixtures: text-delta and unknown turn/end kind must return None (fail-open)
+    assert!(parse_contract_event(
+        AgentSource::Dsh,
+        &fixture("dsh-v0.1.0-rc.6/text-delta-ignored.json")
+    )
+    .unwrap()
+    .is_none());
+    assert!(parse_contract_event(
+        AgentSource::Dsh,
+        &fixture("dsh-v0.1.0-rc.6/unknown-turn-end-kind.json")
+    )
+    .unwrap()
+    .is_none());
+
+    // 7. Privacy fixtures: arguments and child messages must NOT cross into contract event
+    let privacy_tool = parsed(
+        AgentSource::Dsh,
+        "dsh-v0.1.0-rc.6/privacy-leak-attempt.json",
+    );
+    assert_eq!(privacy_tool.tool_name.as_deref(), Some("bash"));
+    assert_eq!(privacy_tool.activity_kind.as_deref(), Some("command"));
+    assert!(privacy_tool
+        .activity_content
+        .as_deref()
+        .map_or(true, |c| !c.contains("credentials")
+            && !c.contains("rm -rf")));
+
+    // subagent/end is not an activity-driving event (subagent lifecycle stays in plugin fence)
+    assert!(parse_contract_event(
+        AgentSource::Dsh,
+        &fixture("dsh-v0.1.0-rc.6/subagent-end-no-leak.json")
+    )
+    .unwrap()
+    .is_none());
+}


### PR DESCRIPTION
## Development claim / 开发声明

- Domain: `agent-connections`
- Claim: `dsh-connector`
- Base commit: `95711d4ded6211a342e29b6ac7ef0830764a14f1`
- Release preparation: `no`
- Focused validation:
  - `cargo test -p petcore --test integration_d --locked`
  - `./script/validate_connectors_runtime.sh`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":3,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-18T11:37:18Z","train_conflict_resolutions":0} -->