### PR TITLE
fix(connections): retain DSH live session bubbles

### DIFF
--- a/changes/unreleased/dsh-live-bubble-projection-4d7f18a.json
+++ b/changes/unreleased/dsh-live-bubble-projection-4d7f18a.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Fixed",
+  "scope": "connections",
+  "summary_en": "Keep DeepSeek Harness visible in the five-Agent connection snapshot and preserve completed or failed WebUI session bubbles across terminal turn events until the normal timeout, acknowledgement, or explicit session disposal applies.",
+  "summary_zh": "在五 Agent 连接快照中保留 DeepSeek Harness，并让已完成或失败的 WebUI 会话气泡在终结轮次后继续显示，直至正常超时、用户确认或宿主明确释放会话。"
+}

--- a/crates/petcore/src/adapter_contracts.rs
+++ b/crates/petcore/src/adapter_contracts.rs
@@ -400,7 +400,10 @@ fn parse_dsh(source: AgentSource, input: &Value) -> Result<Option<ContractEvent>
         },
         project_label: project_label(input),
         session_title: session_title(input),
-        session_open: Some(event != "session/disposed" && (event != "turn/end" || session_active)),
+        // A terminal turn ends current work, not the WebUI session itself.
+        // Keep completed, failed, and aborted sessions projected until dsh
+        // emits the authoritative session/disposed lifecycle boundary.
+        session_open: Some(event != "session/disposed"),
         session_surface: None,
         terminal_app: None,
         session_open_url: None,
@@ -2863,6 +2866,7 @@ mod dsh_adapter_tests {
         assert_eq!(done.kind, AgentEventType::Done);
         assert_eq!(done.outcome.as_deref(), Some("completed"));
         assert!(!done.session_active);
+        assert_eq!(done.session_open, Some(true));
 
         // 11. turn/end completed (fence active) -> Start / background_active / active
         let bg_active = parse(&json!({
@@ -2884,6 +2888,7 @@ mod dsh_adapter_tests {
         assert_eq!(failed.kind, AgentEventType::Failed);
         assert_eq!(failed.outcome.as_deref(), Some("api_failure"));
         assert!(!failed.session_active);
+        assert_eq!(failed.session_open, Some(true));
 
         // 13. turn/end blocked -> Waiting / blocked
         let blocked = parse(&json!({
@@ -2902,6 +2907,7 @@ mod dsh_adapter_tests {
         }));
         assert_eq!(aborted.kind, AgentEventType::Done);
         assert_eq!(aborted.outcome.as_deref(), Some("aborted"));
+        assert_eq!(aborted.session_open, Some(true));
 
         // 15. turn/end max-tokens -> Start / max_tokens / active
         let max_tokens = parse(&json!({

--- a/crates/petcore/src/rpc/mod.rs
+++ b/crates/petcore/src/rpc/mod.rs
@@ -66,7 +66,7 @@ const MAX_CODEX_THREAD_DISPLAY_CACHE_ENTRIES: usize = 64;
 const CODEX_ACTIVITY_REFRESH_SECONDS: u64 = 1;
 const CONNECTION_LIGHT_STATUS_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
 const CONNECTION_EVIDENCE_REFRESH_COALESCE_WINDOW: Duration = Duration::from_secs(5);
-const MAX_CACHED_CONNECTION_STATUSES: usize = 4;
+const MAX_CACHED_CONNECTION_STATUSES: usize = 5;
 const MAX_CACHED_SESSION_DISPLAY_ENTRIES: usize = 16;
 const MAX_SNAPSHOT_REVISION_RETRIES: usize = 8;
 const MAX_FALLBACK_SESSION_TITLE_CHARS: usize = 80;
@@ -3405,6 +3405,42 @@ mod tests {
             )
             .unwrap();
         assert_eq!(calls.load(Ordering::SeqCst), 4);
+    }
+
+    #[test]
+    fn connection_light_status_cache_retains_the_full_five_agent_catalog() {
+        let cache = ConnectionLightStatusCache::default();
+        let statuses = [
+            AgentSource::Codex,
+            AgentSource::ClaudeCode,
+            AgentSource::Pi,
+            AgentSource::Opencode,
+            AgentSource::Dsh,
+        ]
+        .into_iter()
+        .map(|source| AgentConnectionStatus {
+            source,
+            items: Vec::new(),
+            install_paths: Vec::new(),
+            connector_installed: false,
+            verification: petcore_types::AgentVerification::default(),
+            capabilities: petcore_types::AgentConnectorCapabilities::default(),
+            check_mode: petcore_types::ConnectionCheckMode::Light,
+            checked_at: now_rfc3339(),
+        })
+        .collect::<Vec<_>>();
+
+        let cached = cache
+            .get_or_try_refresh(Instant::now(), CONNECTION_LIGHT_STATUS_CACHE_TTL, 1, || {
+                Ok(statuses)
+            })
+            .unwrap();
+
+        assert_eq!(cached.len(), 5);
+        assert_eq!(
+            cached.last().map(|status| status.source),
+            Some(AgentSource::Dsh)
+        );
     }
 
     #[test]

--- a/crates/petcore/src/storage/agents.rs
+++ b/crates/petcore/src/storage/agents.rs
@@ -1384,6 +1384,10 @@ impl Database {
                             'message.user',
                             'session.next.prompt.admitted'
                           )
+                          OR (
+                            source = 'dsh'
+                            AND json_extract(payload_json, '$.source_event') = 'turn/start'
+                          )
                         )
                        THEN created_at
                      END) OVER (PARTITION BY source, session_key) AS session_activated_at,
@@ -1469,6 +1473,27 @@ impl Database {
                               OR (
                                 json_extract(payload_json, '$.source_event') = 'session.status'
                                 AND json_extract(payload_json, '$.outcome') IN ('busy', 'retry')
+                              )
+                            )
+                          )
+                          OR (
+                            source = 'dsh'
+                            AND (
+                              json_extract(payload_json, '$.source_event') IN (
+                                'turn/start',
+                                'assistant/chunk',
+                                'plan/mode',
+                                'todo/write',
+                                'tool/call',
+                                'approval/asked',
+                                'approval/decided'
+                              )
+                              OR (
+                                json_extract(payload_json, '$.source_event') = 'turn/end'
+                                AND json_extract(payload_json, '$.outcome') IN (
+                                  'background_active',
+                                  'max_tokens'
+                                )
                               )
                             )
                           )

--- a/crates/petcore/tests/integration_d/agent_state_arbitration.rs
+++ b/crates/petcore/tests/integration_d/agent_state_arbitration.rs
@@ -3479,6 +3479,128 @@ fn explicit_close_removes_latched_failure_and_stays_closed_across_restart() {
 }
 
 #[test]
+fn dsh_turn_start_without_message_role_activates_terminal_projection_and_new_epoch() {
+    let temp = tempfile::tempdir().unwrap();
+    let paths = AppPaths::new(temp.path().join("home"));
+    let state = CoreState::new(paths.clone());
+    state.ensure_ready().unwrap();
+
+    let ingest_dsh = |state: &CoreState,
+                      event_id: &str,
+                      session_id: &str,
+                      event_type: &str,
+                      source_event: &str,
+                      outcome: &str,
+                      seconds_ago: i64,
+                      session_active: bool| {
+        ingest_source_payload(
+            state,
+            "dsh",
+            event_id,
+            session_id,
+            event_type,
+            &timestamp(seconds_ago),
+            json!({
+                "source_event": source_event,
+                "outcome": outcome,
+                "affects_activity": true,
+                "session_active": session_active,
+                "session_open": true,
+                "session_surface": "cli_terminal"
+            }),
+        );
+    };
+
+    ingest_dsh(
+        &state,
+        "dsh-completed-start",
+        "dsh-completed-real-shape",
+        "start",
+        "turn/start",
+        "started",
+        12,
+        true,
+    );
+    ingest_dsh(
+        &state,
+        "dsh-completed-end",
+        "dsh-completed-real-shape",
+        "done",
+        "turn/end",
+        "completed",
+        11,
+        false,
+    );
+
+    ingest_dsh(
+        &state,
+        "dsh-retry-start-1",
+        "dsh-retry-real-shape",
+        "start",
+        "turn/start",
+        "started",
+        10,
+        true,
+    );
+    ingest_dsh(
+        &state,
+        "dsh-retry-failed",
+        "dsh-retry-real-shape",
+        "failed",
+        "turn/end",
+        "api_failure",
+        9,
+        false,
+    );
+    ingest_dsh(
+        &state,
+        "dsh-retry-start-2",
+        "dsh-retry-real-shape",
+        "start",
+        "turn/start",
+        "started",
+        2,
+        true,
+    );
+    ingest_dsh(
+        &state,
+        "dsh-retry-thinking",
+        "dsh-retry-real-shape",
+        "thinking",
+        "assistant/chunk",
+        "reasoning_started",
+        1,
+        true,
+    );
+
+    let assert_projection = |current: &Value| {
+        let sessions = current["active_agent_sessions"].as_array().unwrap();
+        let completed = sessions
+            .iter()
+            .find(|session| {
+                session["session_id"] == projected_session_id("dsh-completed-real-shape")
+            })
+            .expect("a real-shape DSH completion remains visible");
+        assert_eq!(completed["official_status"], "ready");
+        assert_eq!(completed["event"]["event_type"], "done");
+
+        let retried = sessions
+            .iter()
+            .find(|session| session["session_id"] == projected_session_id("dsh-retry-real-shape"))
+            .expect("a new real-shape DSH turn clears the prior failure epoch");
+        assert_eq!(retried["official_status"], "running");
+        assert_eq!(retried["event"]["event_type"], "thinking");
+    };
+
+    assert_projection(&snapshot(&state));
+    drop(state);
+
+    let restarted = CoreState::new(paths);
+    restarted.ensure_ready().unwrap();
+    assert_projection(&snapshot(&restarted));
+}
+
+#[test]
 fn every_agent_refreshes_reply_completion_and_next_user_turn() {
     let (_temp, state) = ready();
     for (source, session_id, user_event, reply_event, reply_type, followup_done_event) in [

--- a/crates/petcore/tests/integration_d/connector_contracts.rs
+++ b/crates/petcore/tests/integration_d/connector_contracts.rs
@@ -1413,12 +1413,14 @@ fn dsh_contract_fixtures_parse_authoritatively_with_bounds_and_privacy() {
     assert_eq!(completed.kind, AgentEventType::Done);
     assert_eq!(completed.outcome.as_deref(), Some("completed"));
     assert!(!completed.session_active);
+    assert_eq!(completed.session_open, Some(true));
 
     // 2. turn-end-error -> Failed / stable api_failure (host code/message not leaked)
     let error = parsed(AgentSource::Dsh, "dsh-v0.1.0-rc.6/turn-end-error.json");
     assert_eq!(error.kind, AgentEventType::Failed);
     assert_eq!(error.outcome.as_deref(), Some("api_failure"));
     assert!(!error.session_active);
+    assert_eq!(error.session_open, Some(true));
 
     // 3. block-start-reasoning -> Thinking / reasoning_started / active
     let thinking = parsed(


### PR DESCRIPTION
## Summary

- retain all five Agent connection statuses so DeepSeek Harness is not truncated from App snapshots
- distinguish a DSH terminal turn from explicit WebUI session disposal
- recognize real DSH `turn/start` events as session activation and activity-epoch boundaries
- add realistic persistence/restart regressions for DSH completed and retried sessions

## Validation

- `cargo test -p petcore --test integration_d` (163 passed)
- `cargo test -p petcore dsh_adapter_tests`
- `cargo test -p petcore connection_light_status_cache_`
- `./script/validate_connectors_runtime.sh`
- `./script/validate_pre_push.sh`
- `./script/build_and_run.sh --run`
- live DSH WebUI tasks observed as `DeepSeek Harness · CLI` in both running and completed bubbles; completed sessions survived App/PetCore restart with `session_open=true`

## Development claim / 开发声明

- Domain: `agent-connections`
- Claim: `dsh-connector`
- Base commit: `91aabc4870d8cc05dd492153b85b98752ab3eda1`
- Release preparation: `no`
- Focused validation:
  - `cargo test -p petcore --test integration_d --locked`
  - `./script/validate_connectors_runtime.sh`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":0,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-18T17:49:26Z","train_conflict_resolutions":0} -->