### PR TITLE
fix(ci): wait for merged PR identity

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -150,12 +150,31 @@ jobs:
             gh pr merge --repo "$GITHUB_REPOSITORY" --squash --match-head-commit "$HEAD_SHA" "$PR_URL"
             newly_merged=1
           fi
-          pull="$(
-            gh api \
-              -H 'Accept: application/vnd.github+json' \
-              -H 'X-GitHub-Api-Version: 2026-03-10' \
-              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER"
-          )"
+          pull=""
+          merge_observed=0
+          for attempt in 1 2 3 4 5 6; do
+            pull="$(
+              gh api \
+                -H 'Accept: application/vnd.github+json' \
+                -H 'X-GitHub-Api-Version: 2026-03-10' \
+                "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER"
+            )"
+            if jq -e \
+              --arg base_branch "$BASE_BRANCH" \
+              --arg head_sha "$HEAD_SHA" \
+              '.merged == true and
+               .base.ref == $base_branch and
+               .head.sha == $head_sha and
+               (.merge_commit_sha | strings | test("^[0-9a-f]{40}$"))' \
+              <<<"$pull" >/dev/null; then
+              merge_observed=1
+              break
+            fi
+            if ((attempt < 6)); then
+              sleep 2
+            fi
+          done
+          test "$merge_observed" = "1"
           test "$(jq -er '.merged' <<<"$pull")" = "true"
           test "$(jq -er '.base.ref' <<<"$pull")" = "$BASE_BRANCH"
           test "$(jq -er '.head.sha' <<<"$pull")" = "$HEAD_SHA"

--- a/script/tests/test_release_distribution_contracts.py
+++ b/script/tests/test_release_distribution_contracts.py
@@ -1135,6 +1135,16 @@ class CIWorkflowContractTests(unittest.TestCase):
         self.assertIn("./script/ci_proof_promotion.py delete-merged-head", source)
         self.assertIn("newly_merged=$newly_merged", source)
         self.assertIn('--allow-delete "$ALLOW_DELETE"', source)
+        merge_step = source[
+            source.index("Squash or recover only the PR proven") : source.index(
+                "Dispatch exact merged main commit validation"
+            )
+        ]
+        self.assertIn("merge_observed=0", merge_step)
+        self.assertIn("for attempt in 1 2 3 4 5 6", merge_step)
+        self.assertIn('test "$merge_observed" = "1"', merge_step)
+        self.assertIn(".merged == true", merge_step)
+        self.assertLess(merge_step.index("gh pr merge"), merge_step.index("merge_observed=0"))
         cleanup = source.index("./script/ci_proof_promotion.py delete-merged-head")
         self.assertGreater(cleanup, source.index("Squash or recover only the PR proven"))
         self.assertGreater(cleanup, source.index("Dispatch exact merged main commit validation"))


### PR DESCRIPTION
## Summary

- wait for GitHub's authoritative pull-request response to expose the newly merged identity after a successful squash
- keep the existing exact base/head/SHA fail-closed checks after a bounded retry window
- add a workflow contract regression that requires merge observation to happen after the merge command

## Incident evidence

- protected merge run `32168497595` successfully merged PR #44, then failed in `Squash or recover only the PR proven by the completed CI run`
- the same failure shape occurred after PR #43
- because merges performed with the workflow token do not trigger a fresh workflow automatically, the failure skipped exact-SHA main CI dispatch and source-branch cleanup

## Validation

- `python3 script/tests/test_validation_tooling.py` (58 passed)
- `python3 script/tests/test_release_distribution_contracts.py` (44 passed)
- `./script/validate_build_scripts_safety.sh --static-only`
- `./script/validate_source_syntax.sh`
- `./script/validate_pre_push.sh`

This PR changes the protected delivery control plane and therefore requires a trusted manual squash merge after CI.

## Development claim / 开发声明

- Domain: `release-control-plane`
- Claim: `control-plane`
- Base commit: `964f69f128cd0a41305afe5fd734880dabb47552`
- Release preparation: `no`
- Focused validation:
  - `python3 script/tests/test_validation_tooling.py`
  - `./script/validate_build_scripts_safety.sh --static-only`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":0,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-18T18:05:06Z","train_conflict_resolutions":0} -->