### PR TITLE
test: isolate generation worker environment

### DIFF
--- a/crates/petcore/src/generation.rs
+++ b/crates/petcore/src/generation.rs
@@ -186,6 +186,34 @@ fn wait_for_generation_worker_stop(job_id: &str, timeout: Duration) -> bool {
         .unwrap_or(false)
 }
 
+/// Waits for every generation worker that is currently registered to finish.
+///
+/// This is intentionally public only for process-isolation tests. Generation
+/// workers can outlive the RPC that launched them, so a test must not replace
+/// process-wide App Server configuration until older workers have released it.
+#[doc(hidden)]
+pub fn wait_for_generation_workers_idle(timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let job_ids = generation_worker_registry()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        if job_ids.is_empty() {
+            return true;
+        }
+
+        for job_id in job_ids {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() || !wait_for_generation_worker_stop(&job_id, remaining) {
+                return false;
+            }
+        }
+    }
+}
+
 impl ProductionReadiness {
     fn usable(self) -> bool {
         self.build_ok && self.package_ok && self.interaction_ok && self.runtime_ok && self.visual_ok

--- a/crates/petcore/tests/integration_a/core_validation.rs
+++ b/crates/petcore/tests/integration_a/core_validation.rs
@@ -60,7 +60,12 @@ impl Drop for EnvVarGuard {
 }
 
 fn lock_env() -> std::sync::MutexGuard<'static, ()> {
-    crate::test_support::lock_process_state()
+    let guard = crate::test_support::lock_process_state();
+    assert!(
+        generation::wait_for_generation_workers_idle(Duration::from_secs(10)),
+        "a previous generation worker did not stop before process-wide test configuration changed"
+    );
+    guard
 }
 
 fn projected_event_id(value: &str) -> String {

--- a/crates/petcore/tests/integration_b/generation_lifecycle.rs
+++ b/crates/petcore/tests/integration_b/generation_lifecycle.rs
@@ -1,6 +1,7 @@
 use petcore::paths::AppPaths;
 use petcore::petpack::{build_petpack, write_generated_petpack_dir, write_sample_petpack_dir};
 use petcore::rpc::{handle_request, CoreState, RpcRequest};
+use petcore::PetCoreError;
 use petcore_types::{
     GenerationForm, GenerationJobStatus, PetOrigin, PetStateName, PetSummary, QualityLevel,
     MAX_GENERATION_DESCRIPTION_CHARS,
@@ -154,6 +155,26 @@ fn request(method: &str, params: Value) -> RpcRequest {
         id: Some(json!("test")),
         method: method.to_string(),
         params,
+    }
+}
+
+fn state_snapshot_with_revision_retry(state: &CoreState) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match handle_request(state, request("state.snapshot", json!({}))) {
+            Ok(snapshot) => return snapshot,
+            Err(PetCoreError::Conflict(message))
+                if message
+                    == "state changed while hydrating session displays; retry the snapshot" =>
+            {
+                assert!(
+                    Instant::now() < deadline,
+                    "state snapshot did not stabilize while generation remained active"
+                );
+                std::thread::yield_now();
+            }
+            Err(error) => panic!("state snapshot failed unexpectedly: {error}"),
+        }
     }
 }
 
@@ -1017,7 +1038,7 @@ fn imported_pet_can_start_codex_edit_as_same_id_revision() {
     .unwrap();
     assert_eq!(historical_edit["baseline_revision_id"], original_revision);
     let historical_job_id = historical_edit["job_id"].as_str().unwrap();
-    let active_snapshot = handle_request(&state, request("state.snapshot", json!({}))).unwrap();
+    let active_snapshot = state_snapshot_with_revision_retry(&state);
     assert_eq!(
         active_snapshot["active_generation"]["baseline_revision_id"],
         original_revision


### PR DESCRIPTION
## Summary
- wait for registered Pet Studio generation workers to stop before integration tests replace process-wide App Server configuration
- prevent an older asynchronous worker from invoking the next test's fake App Server command and producing a false failure
- retry only the documented transient `state.snapshot` revision conflict while an active generation worker advances state

## Validation
- exact failing `integration_a` test passed
- full `integration_a` shard repeated 3 times: 96/96 each run
- exact failing `integration_b` test passed
- full `integration_b` shard repeated 3 times: 40/40 each run
- `./script/validate_pre_push.sh`

## CI failures addressed
- main run 32169784445, integration-a job 95818451253
- PR run 32171052173, integration-b job 95822542296