### PR TITLE
Prepare Agent Pet Companion 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,68 @@ Keep each user-visible change in its own bullet. Write the English text first, t
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-19
+
+### Added / 新增
+
+<!-- apc-fragment:1-dsh-source-type -->
+- Extend the Agent source vocabulary to include DeepSeek Harness (dsh) with conservative no-op behavior while connector management lands.
+
+  Agent 来源词汇扩展纳入 DeepSeek Harness（dsh），在连接器管理落地前保持保守无行为扩展。
+<!-- apc-fragment:2-dsh-parse -->
+- Add DeepSeek Harness (dsh) hook event normalization covering all seven semantic states, reasoning boundaries, and background fence.
+
+  新增 DeepSeek Harness（dsh）Hook 事件归一化，覆盖全部七种语义状态、reasoning 边界与后台工作栅栏。
+<!-- apc-fragment:3-dsh-connections -->
+- Add DeepSeek Harness (dsh) connector managed lifecycle: check, repair, refresh, and uninstall targeting the web profile cordis.patch.yml.
+
+  新增 DeepSeek Harness（dsh）连接器受管生命周期：面向 web profile cordis.patch.yml 的 check、repair、refresh 与 uninstall 操作。
+<!-- apc-fragment:4-dsh-plugin-template -->
+- Add DeepSeek Harness (dsh) Cordis plugin template implementing single-flight delivery, reasoning block-start thinking, child session suppression, and background fence.
+
+  新增 DeepSeek Harness（dsh）Cordis 插件模板，实现单飞队列交付、reasoning block-start 思考边界、子会话抑制与后台工作栅栏。
+<!-- apc-fragment:5-dsh-app-surface -->
+- Add DeepSeek Harness (dsh) to App-side runtime manifest and Agent Connections UI surfaces.
+
+  在 App 端运行时清单与 Agent 连接设置页面中接入 DeepSeek Harness（dsh）。
+<!-- apc-fragment:6-dsh-e2e -->
+- Add end-to-end integration tests for DeepSeek Harness (dsh) verifying contract fixtures, bounds, and privacy enforcement.
+
+  新增 DeepSeek Harness（dsh）端到端集成测试，验证契约测试用例、字段有界性与隐私约束。
+<!-- apc-fragment:7-dsh-docs -->
+- Incorporate DeepSeek Harness (dsh) connector contract, event mapping, privacy boundaries, and managed patch architecture into durable documentation.
+
+  将 DeepSeek Harness（dsh）连接器契约、事件映射、隐私边界与受管 patch 架构并入正式技术文档。
+<!-- apc-fragment:8-dsh-scope -->
+- Expand repository product scope from four to five supported Agents, incorporating DeepSeek Harness across AGENTS.md, README, and architecture documentation.
+
+  扩展产品范围支持五款 Agent，在 AGENTS.md、中英文 README 与架构文档中同步纳入 DeepSeek Harness。
+
+### Changed / 变更
+
+<!-- apc-fragment:20260819-dsh-webui-icon -->
+- DeepSeek Harness now uses the official WebUI fish icon throughout the App.
+
+  DeepSeek Harness 现已在 App 各处统一使用官方 WebUI 鱼形图标。
+
+### Fixed / 修复
+
+<!-- apc-fragment:20260819-dsh-bubble-message -->
+- DeepSeek Harness tasks now keep the latest Agent, thinking, or plan text in the desktop bubble while tools run, instead of showing an empty body until the task ends.
+
+  DeepSeek Harness 任务在工具运行期间，桌面气泡会持续保留最新的 Agent、思考或计划正文，不再在任务结束前一直显示空正文。
+<!-- apc-fragment:closed-failed-bubble-restart-87e069b -->
+- Explicitly closed Agent sessions no longer restore stale failure bubbles when the pet or PetCore reopens.
+
+  已明确关闭的 Agent 会话不会在宠物或 PetCore 重新打开后恢复陈旧的失败气泡。
+<!-- apc-fragment:dsh-acceptance-hardening-9f4c2a1 -->
+- Complete DSH acceptance across five-Agent defaults, checks, receipts, display context, explicit session close, stable event identity, safe managed configuration, and legacy runtime rollback decoding.
+
+  完成 DSH 五 Agent 默认设置、检查与回执、气泡上下文、会话显式关闭、稳定事件身份、安全托管配置及旧运行时回滚解码的验收修复。
+<!-- apc-fragment:dsh-live-bubble-projection-4d7f18a -->
+- Keep DeepSeek Harness visible in the five-Agent connection snapshot and preserve completed or failed WebUI session bubbles across terminal turn events until the normal timeout, acknowledgement, or explicit session disposal applies.
+
+  在五 Agent 连接快照中保留 DeepSeek Harness，并让已完成或失败的 WebUI 会话气泡在终结轮次后继续显示，直至正常超时、用户确认或宿主明确释放会话。
 ## [0.4.6] - 2026-08-17
 
 ### Changed / 变更

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petcore"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "hex",
  "image",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-cli"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "petcore",
  "petcore-types",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-types"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/changes/unreleased/1-dsh-source-type.json
+++ b/changes/unreleased/1-dsh-source-type.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Added",
-  "scope": "connections",
-  "summary_en": "Extend the Agent source vocabulary to include DeepSeek Harness (dsh) with conservative no-op behavior while connector management lands.",
-  "summary_zh": "Agent 来源词汇扩展纳入 DeepSeek Harness（dsh），在连接器管理落地前保持保守无行为扩展。"
-}

--- a/changes/unreleased/2-dsh-parse.json
+++ b/changes/unreleased/2-dsh-parse.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Added",
-  "scope": "connections",
-  "summary_en": "Add DeepSeek Harness (dsh) hook event normalization covering all seven semantic states, reasoning boundaries, and background fence.",
-  "summary_zh": "新增 DeepSeek Harness（dsh）Hook 事件归一化，覆盖全部七种语义状态、reasoning 边界与后台工作栅栏。"
-}

--- a/changes/unreleased/20260819-dsh-bubble-message.json
+++ b/changes/unreleased/20260819-dsh-bubble-message.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "dsh",
-  "summary_en": "DeepSeek Harness tasks now keep the latest Agent, thinking, or plan text in the desktop bubble while tools run, instead of showing an empty body until the task ends.",
-  "summary_zh": "DeepSeek Harness 任务在工具运行期间，桌面气泡会持续保留最新的 Agent、思考或计划正文，不再在任务结束前一直显示空正文。"
-}

--- a/changes/unreleased/20260819-dsh-webui-icon.json
+++ b/changes/unreleased/20260819-dsh-webui-icon.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Changed",
-  "scope": "dsh",
-  "summary_en": "DeepSeek Harness now uses the official WebUI fish icon throughout the App.",
-  "summary_zh": "DeepSeek Harness 现已在 App 各处统一使用官方 WebUI 鱼形图标。"
-}

--- a/changes/unreleased/3-dsh-connections.json
+++ b/changes/unreleased/3-dsh-connections.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Added",
-  "scope": "connections",
-  "summary_en": "Add DeepSeek Harness (dsh) connector managed lifecycle: check, repair, refresh, and uninstall targeting the web profile cordis.patch.yml.",
-  "summary_zh": "新增 DeepSeek Harness（dsh）连接器受管生命周期：面向 web profile cordis.patch.yml 的 check、repair、refresh 与 uninstall 操作。"
-}

--- a/changes/unreleased/4-dsh-plugin-template.json
+++ b/changes/unreleased/4-dsh-plugin-template.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Added",
-  "scope": "connections",
-  "summary_en": "Add DeepSeek Harness (dsh) Cordis plugin template implementing single-flight delivery, reasoning block-start thinking, child session suppression, and background fence.",
-  "summary_zh": "新增 DeepSeek Harness（dsh）Cordis 插件模板，实现单飞队列交付、reasoning block-start 思考边界、子会话抑制与后台工作栅栏。"
-}

--- a/changes/unreleased/5-dsh-app-surface.json
+++ b/changes/unreleased/5-dsh-app-surface.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Added",
-  "scope": "connections",
-  "summary_en": "Add DeepSeek Harness (dsh) to App-side runtime manifest and Agent Connections UI surfaces.",
-  "summary_zh": "在 App 端运行时清单与 Agent 连接设置页面中接入 DeepSeek Harness（dsh）。"
-}

--- a/changes/unreleased/6-dsh-e2e.json
+++ b/changes/unreleased/6-dsh-e2e.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Added",
-  "scope": "connections",
-  "summary_en": "Add end-to-end integration tests for DeepSeek Harness (dsh) verifying contract fixtures, bounds, and privacy enforcement.",
-  "summary_zh": "新增 DeepSeek Harness（dsh）端到端集成测试，验证契约测试用例、字段有界性与隐私约束。"
-}

--- a/changes/unreleased/7-dsh-docs.json
+++ b/changes/unreleased/7-dsh-docs.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Added",
-  "scope": "documentation",
-  "summary_en": "Incorporate DeepSeek Harness (dsh) connector contract, event mapping, privacy boundaries, and managed patch architecture into durable documentation.",
-  "summary_zh": "将 DeepSeek Harness（dsh）连接器契约、事件映射、隐私边界与受管 patch 架构并入正式技术文档。"
-}

--- a/changes/unreleased/8-dsh-scope.json
+++ b/changes/unreleased/8-dsh-scope.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Added",
-  "scope": "documentation",
-  "summary_en": "Expand repository product scope from four to five supported Agents, incorporating DeepSeek Harness across AGENTS.md, README, and architecture documentation.",
-  "summary_zh": "扩展产品范围支持五款 Agent，在 AGENTS.md、中英文 README 与架构文档中同步纳入 DeepSeek Harness。"
-}

--- a/changes/unreleased/closed-failed-bubble-restart-87e069b.json
+++ b/changes/unreleased/closed-failed-bubble-restart-87e069b.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "overlay",
-  "summary_en": "Explicitly closed Agent sessions no longer restore stale failure bubbles when the pet or PetCore reopens.",
-  "summary_zh": "已明确关闭的 Agent 会话不会在宠物或 PetCore 重新打开后恢复陈旧的失败气泡。"
-}

--- a/changes/unreleased/dsh-acceptance-hardening-9f4c2a1.json
+++ b/changes/unreleased/dsh-acceptance-hardening-9f4c2a1.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "connections",
-  "summary_en": "Complete DSH acceptance across five-Agent defaults, checks, receipts, display context, explicit session close, stable event identity, safe managed configuration, and legacy runtime rollback decoding.",
-  "summary_zh": "完成 DSH 五 Agent 默认设置、检查与回执、气泡上下文、会话显式关闭、稳定事件身份、安全托管配置及旧运行时回滚解码的验收修复。"
-}

--- a/changes/unreleased/dsh-live-bubble-projection-4d7f18a.json
+++ b/changes/unreleased/dsh-live-bubble-projection-4d7f18a.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "connections",
-  "summary_en": "Keep DeepSeek Harness visible in the five-Agent connection snapshot and preserve completed or failed WebUI session bubbles across terminal turn events until the normal timeout, acknowledgement, or explicit session disposal applies.",
-  "summary_zh": "在五 Agent 连接快照中保留 DeepSeek Harness，并让已完成或失败的 WebUI 会话气泡在终结轮次后继续显示，直至正常超时、用户确认或宿主明确释放会话。"
-}

--- a/crates/petcore-cli/Cargo.toml
+++ b/crates/petcore-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-cli"
-version = "0.4.6"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore-types/Cargo.toml
+++ b/crates/petcore-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-types"
-version = "0.4.6"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore/Cargo.toml
+++ b/crates/petcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore"
-version = "0.4.6"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
## Summary

- prepare Agent Pet Companion `0.5.0` from the complete frozen 13-fragment inventory
- synchronize PetCore, CLI, types, and Cargo lock identities at `0.5.0`
- consume the DeepSeek Harness (dsh) connector, five-Agent scope, WebUI fish icon, live bubble, and session lifecycle fixes into the bilingual release changelog

## Impact

This release adds support for DeepSeek Harness (dsh), expanding supported Agent integrations from 4 to 5, and delivers desktop bubble and session projection improvements.

## Validation

- `python3 script/development_domains.py validate` (11 domains)
- `python3 script/tests/test_validation_tooling.py` (58 passed)
- `./script/validate_build_scripts_safety.sh --static-only`
- `python3 script/tests/test_release_distribution_contracts.py` (45 passed)
- `python3 script/validate_codex_plugin_version.py --base-ref v0.4.6`
- `cargo check --workspace --all-targets --locked`
- `./script/validate_pre_push.sh --base origin/main`
- `./script/changelog_fragments.py require-consumed`
- `./script/changelog_fragments.py policy --base-ref origin/main --release-preparation true`

## Development claim / 开发声明

- Domain: `release-control-plane`
- Claim: `control-plane`
- Base commit: `0c2e9b33c71621b8dbba336779620147c6bad612`
- Release preparation: `yes`
- Focused validation:
  - `python3 script/tests/test_validation_tooling.py`
  - `./script/validate_build_scripts_safety.sh --static-only`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":1,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-19T07:44:50Z","train_conflict_resolutions":0} -->