### PR TITLE
Cap standalone session title width

### DIFF
--- a/apps/macos/Sources/AgentPetCompanion/Overlay/OverlayBubbleTypography.swift
+++ b/apps/macos/Sources/AgentPetCompanion/Overlay/OverlayBubbleTypography.swift
@@ -12,6 +12,11 @@ import SwiftUI
 /// same values, so a taller row is measured before the panel is sized rather
 /// than discovered as clipped text.
 enum OverlayBubbleTypography {
+    /// Standalone cards render the title and retained Agent body as one inline
+    /// summary. Capping the title at two thirds of that line keeps enough room
+    /// for a reply or narrative activity to remain visible on the first line.
+    static let standaloneSessionTitleLineFraction: CGFloat = 2.0 / 3.0
+
     static func pointSize(
         _ style: NSFont.TextStyle,
         scale: BubbleFontScale
@@ -32,6 +37,46 @@ enum OverlayBubbleTypography {
         scale: BubbleFontScale
     ) -> NSFont {
         NSFont.systemFont(ofSize: pointSize(style, scale: scale))
+    }
+
+    static func standaloneSessionTitle(
+        _ title: String,
+        availableLineWidth: CGFloat,
+        scale: BubbleFontScale
+    ) -> String {
+        guard availableLineWidth.isFinite, availableLineWidth > 0 else {
+            return title
+        }
+        let maximumWidth = availableLineWidth * standaloneSessionTitleLineFraction
+        let font = NSFont.systemFont(
+            ofSize: pointSize(.callout, scale: scale),
+            weight: .semibold
+        )
+        guard measuredTextWidth(title, font: font) > maximumWidth else {
+            return title
+        }
+
+        let ellipsis = "…"
+        guard measuredTextWidth(ellipsis, font: font) <= maximumWidth else {
+            return ""
+        }
+        let characters = Array(title)
+        var lowerBound = 0
+        var upperBound = characters.count
+        while lowerBound < upperBound {
+            let candidateCount = (lowerBound + upperBound + 1) / 2
+            let candidate = String(characters.prefix(candidateCount)) + ellipsis
+            if measuredTextWidth(candidate, font: font) <= maximumWidth {
+                lowerBound = candidateCount
+            } else {
+                upperBound = candidateCount - 1
+            }
+        }
+        return String(characters.prefix(lowerBound)) + ellipsis
+    }
+
+    static func measuredTextWidth(_ text: String, font: NSFont) -> CGFloat {
+        ceil((text as NSString).size(withAttributes: [.font: font]).width)
     }
 
     /// Scales a control box that exists only to hold bubble text or a glyph

--- a/apps/macos/Sources/AgentPetCompanion/Overlay/OverlayRootView.swift
+++ b/apps/macos/Sources/AgentPetCompanion/Overlay/OverlayRootView.swift
@@ -450,41 +450,68 @@ private struct ConversationBubble: View {
     }
 
     private func standaloneSessionSurface(_ session: OverlaySessionContent) -> some View {
-        let accessoryWidth = OverlayGeometry.bubbleHeaderButtonSize(fontScale: fontScale)
-            + OverlayGeometry.bubbleHeaderGap
-        return ZStack(alignment: .topTrailing) {
-            SessionBubbleRow(
-                session: session,
-                action: { performPrimarySessionAction(session) },
-                dismissAction: nil,
-                presentation: .standaloneSummary,
-                agentName: content.agentName,
-                reservedTrailingAccessoryWidth: accessoryWidth,
-                primaryActionLabel: primarySessionActionLabel
+        GeometryReader { proxy in
+            let lineWidth = max(
+                0,
+                proxy.size.width - OverlayGeometry.bubbleSessionHorizontalPadding * 2
             )
+            let visualSession = standaloneVisualSession(
+                session,
+                availableLineWidth: lineWidth
+            )
+            let accessoryWidth = OverlayGeometry.bubbleHeaderButtonSize(fontScale: fontScale)
+                + OverlayGeometry.bubbleHeaderGap
 
-            HStack(spacing: OverlayGeometry.bubbleHeaderGap) {
-                if content.canDismiss {
-                    BubbleIconButton(
-                        systemImage: "xmark",
-                        accessibilityLabel: accessibilityModel.closeActionLabel
-                            ?? APCLocalization.text(.overlayCloseBubbleAccessibility),
-                        accessibilityHint: accessibilityModel.closeActionHint
-                            ?? APCLocalization.text(.overlayCloseBubbleHint),
-                        action: onClose
-                    )
-                    .opacity(hovered || keyboardNavigationActive ? 1 : 0.001)
-                    .animation(
-                        reduceMotion
-                            ? nil
-                            : .easeOut(duration: OverlayMotion.controlFadeDuration),
-                        value: hovered || keyboardNavigationActive
-                    )
-                    .allowsHitTesting(hovered || keyboardNavigationActive)
-                    .accessibilityHidden(false)
+            ZStack(alignment: .topTrailing) {
+                SessionBubbleRow(
+                    session: visualSession,
+                    action: { performPrimarySessionAction(session) },
+                    dismissAction: nil,
+                    presentation: .standaloneSummary,
+                    agentName: content.agentName,
+                    reservedTrailingAccessoryWidth: accessoryWidth,
+                    primaryActionLabel: primarySessionActionLabel
+                )
+                // Only the visual copy is shortened. VoiceOver continues to
+                // receive the complete source title and retained body message.
+                .accessibilityLabel(session.accessibilityLabel)
+
+                HStack(spacing: OverlayGeometry.bubbleHeaderGap) {
+                    if content.canDismiss {
+                        BubbleIconButton(
+                            systemImage: "xmark",
+                            accessibilityLabel: accessibilityModel.closeActionLabel
+                                ?? APCLocalization.text(.overlayCloseBubbleAccessibility),
+                            accessibilityHint: accessibilityModel.closeActionHint
+                                ?? APCLocalization.text(.overlayCloseBubbleHint),
+                            action: onClose
+                        )
+                        .opacity(hovered || keyboardNavigationActive ? 1 : 0.001)
+                        .animation(
+                            reduceMotion
+                                ? nil
+                                : .easeOut(duration: OverlayMotion.controlFadeDuration),
+                            value: hovered || keyboardNavigationActive
+                        )
+                        .allowsHitTesting(hovered || keyboardNavigationActive)
+                        .accessibilityHidden(false)
+                    }
                 }
             }
         }
+    }
+
+    private func standaloneVisualSession(
+        _ session: OverlaySessionContent,
+        availableLineWidth: CGFloat
+    ) -> OverlaySessionContent {
+        var visualSession = session
+        visualSession.sessionTitle = OverlayBubbleTypography.standaloneSessionTitle(
+            session.sessionTitle,
+            availableLineWidth: availableLineWidth,
+            scale: fontScale
+        )
+        return visualSession
     }
 
     private var groupedSessionSurface: some View {

--- a/apps/macos/Tests/AgentPetCompanionTests/OverlayGeometryTests.swift
+++ b/apps/macos/Tests/AgentPetCompanionTests/OverlayGeometryTests.swift
@@ -77,6 +77,65 @@ struct OverlayGeometryTests {
     }
 
     @Test
+    func standaloneSessionTitleUsesAtMostTwoThirdsOfTheSummaryLine() {
+        let availableLineWidth: CGFloat = 300
+        let maximumTitleWidth = availableLineWidth
+            * OverlayBubbleTypography.standaloneSessionTitleLineFraction
+        let longTitles = [
+            "Verify the latest GitHub release app and every desktop integration",
+            "实机验证本产品更新到最新版应用后所有桌宠和智能体连接是否正常",
+        ]
+
+        for fontScale in BubbleFontScale.allCases {
+            let font = NSFont.systemFont(
+                ofSize: OverlayBubbleTypography.pointSize(.callout, scale: fontScale),
+                weight: .semibold
+            )
+            for title in longTitles {
+                let displayed = OverlayBubbleTypography.standaloneSessionTitle(
+                    title,
+                    availableLineWidth: availableLineWidth,
+                    scale: fontScale
+                )
+                #expect(displayed.hasSuffix("…"))
+                #expect(displayed != title)
+                #expect(
+                    OverlayBubbleTypography.measuredTextWidth(displayed, font: font)
+                        <= maximumTitleWidth
+                )
+            }
+        }
+    }
+
+    @Test
+    func standaloneSessionTitleKeepsShortVisualCopyAndFullAccessibilityCopy() {
+        let fullTitle = "A complete title that remains available to VoiceOver after visual truncation"
+        let session = OverlaySessionContent(
+            id: "title-accessibility",
+            source: .codex,
+            sessionID: "title-accessibility",
+            eventType: .thinking,
+            sessionTitle: fullTitle,
+            messageText: "The retained Agent message stays visible.",
+            statusText: "Thinking"
+        )
+        let shortTitle = "Inspect release"
+
+        #expect(OverlayBubbleTypography.standaloneSessionTitle(
+            shortTitle,
+            availableLineWidth: 300,
+            scale: .standard
+        ) == shortTitle)
+        #expect(OverlayBubbleTypography.standaloneSessionTitle(
+            fullTitle,
+            availableLineWidth: 300,
+            scale: .standard
+        ) != fullTitle)
+        #expect(session.accessibilityReadingOrder.contains(fullTitle))
+        #expect(session.accessibilityReadingOrder.contains(session.messageText))
+    }
+
+    @Test
     func displayWidthContractUsesExactRangeAspectAndDefault() {
         #expect(OverlayGeometry.minimumDisplayWidthPt == 100)
         #expect(OverlayGeometry.defaultDisplayWidthPt == 112)

--- a/changes/unreleased/20260819-standalone-session-title-width.json
+++ b/changes/unreleased/20260819-standalone-session-title-width.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Changed",
+  "scope": "overlay",
+  "summary_en": "Standalone Agent session bubbles cap long visual titles at two thirds of the summary line so retained replies remain visible.",
+  "summary_zh": "独立 Agent 会话气泡将过长标题的可视宽度限制为摘要行的三分之二，为后续回复保留展示空间。"
+}


### PR DESCRIPTION
## Summary

- Cap standalone session bubble titles at two thirds of the measured summary line and append an ellipsis when needed.
- Keep the original title for navigation and VoiceOver while reserving visible space for retained Agent replies and activity text.
- Cover Chinese and English titles across all bubble font scales.

## Validation

- ./script/validate_swift_tests.sh --scope overlay — 173 tests passed
- ./script/validate_pre_push.sh — passed
- ./script/build_and_run.sh --run — App and PetCore synchronized on debug build 0.5.0.1.develop.a6054c891b903e37
- Computer Use — observed the live short-title bubble layout without injecting synthetic Agent events

## Development claim / 开发声明

- Domain: overlay-sessions
- Claim: overlay-runtime
- Base commit: bbf94f29038932e94fb9291c092ec3605977c556
- Release preparation: no
- Focused validation:
  - ./script/validate_swift_tests.sh --scope overlay

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":1,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-19T11:07:09Z","train_conflict_resolutions":0} -->