### PR TITLE
Disable invalid DSH web session routing

### DIFF
--- a/changes/unreleased/20260819-dsh-web-session-navigation.json
+++ b/changes/unreleased/20260819-dsh-web-session-navigation.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Fixed",
+  "scope": "dsh",
+  "summary_en": "DeepSeek Harness Web sessions no longer appear as CLI sessions or route bubbles back to the terminal that launched the Web server.",
+  "summary_zh": "DeepSeek Harness Web 会话不再显示为 CLI，也不会从气泡跳回启动 Web 服务的终端。"
+}

--- a/crates/petcore-cli/src/main.rs
+++ b/crates/petcore-cli/src/main.rs
@@ -1734,6 +1734,18 @@ fn runtime_navigation_from_values(
     opencode_client: Option<&str>,
     codex_internal_originator: Option<&str>,
 ) -> RuntimeNavigation {
+    if source == AgentSource::Dsh {
+        return RuntimeNavigation {
+            // The managed dsh connector runs inside the Web profile. The Web
+            // client selects sessions through browser-local runtime state and
+            // exposes no audited session URL, so the terminal that launched
+            // the server is neither the session surface nor a return target.
+            session_surface: Some("unknown".to_string()),
+            terminal_app: None,
+            session_open_url: None,
+        };
+    }
+
     if let Some(session_surface) = runtime_agent_app_surface(
         source,
         bundle_identifier,
@@ -2306,6 +2318,22 @@ mod tests {
         );
         assert_eq!(rejected.session_open_url, None);
         assert_eq!(rejected.session_surface.as_deref(), Some("cli_terminal"));
+    }
+
+    #[test]
+    fn dsh_web_sessions_do_not_inherit_the_server_launch_terminal() {
+        let navigation = runtime_navigation_from_values(
+            AgentSource::Dsh,
+            Some("warp://session/A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4"),
+            Some("WarpTerminal"),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(navigation.session_surface.as_deref(), Some("unknown"));
+        assert_eq!(navigation.terminal_app, None);
+        assert_eq!(navigation.session_open_url, None);
     }
 
     #[test]

--- a/crates/petcore/src/agent_state.rs
+++ b/crates/petcore/src/agent_state.rs
@@ -820,6 +820,20 @@ pub(crate) fn overlay_navigation(event: &AgentEvent) -> OverlaySessionNavigation
     let session_open = payload
         .get("session_open")
         .and_then(serde_json::Value::as_bool);
+    if event.source == AgentSource::Dsh {
+        // The managed dsh integration observes its Web profile. Current dsh
+        // session selection is browser-local and has no external deep link;
+        // older events may still carry the terminal that launched the server,
+        // but that terminal is never a truthful return destination.
+        return OverlaySessionNavigation {
+            capability: OverlayNavigationCapability::Unavailable,
+            session_open,
+            surface: Some("unknown".to_string()),
+            terminal_app: None,
+            open_url: None,
+            routable_session_id: None,
+        };
+    }
     let surface = payload
         .get("session_surface")
         .and_then(serde_json::Value::as_str)
@@ -1220,6 +1234,26 @@ mod tests {
             missing_codex_surface.capability,
             OverlayNavigationCapability::Unavailable
         );
+    }
+
+    #[test]
+    fn dsh_web_navigation_rejects_legacy_launch_terminal_metadata() {
+        let dsh = overlay_navigation(&navigation_event(
+            AgentSource::Dsh,
+            "dsh-web-session",
+            json!({
+                "session_open": true,
+                "session_surface": "cli_terminal",
+                "terminal_app": "warp",
+                "session_open_url": "warp://session/0123456789abcdef0123456789abcdef"
+            }),
+        ));
+        assert_eq!(dsh.capability, OverlayNavigationCapability::Unavailable);
+        assert_eq!(dsh.session_open, Some(true));
+        assert_eq!(dsh.surface.as_deref(), Some("unknown"));
+        assert_eq!(dsh.terminal_app, None);
+        assert_eq!(dsh.open_url, None);
+        assert_eq!(dsh.routable_session_id, None);
     }
 
     #[test]

--- a/crates/petcore/tests/integration_d/agent_state_arbitration.rs
+++ b/crates/petcore/tests/integration_d/agent_state_arbitration.rs
@@ -3610,7 +3610,7 @@ fn explicit_close_removes_latched_failure_and_stays_closed_across_restart() {
 }
 
 #[test]
-fn dsh_turn_start_without_message_role_activates_terminal_projection_and_new_epoch() {
+fn dsh_turn_start_without_message_role_activates_web_projection_and_new_epoch() {
     let temp = tempfile::tempdir().unwrap();
     let paths = AppPaths::new(temp.path().join("home"));
     let state = CoreState::new(paths.clone());
@@ -3637,7 +3637,7 @@ fn dsh_turn_start_without_message_role_activates_terminal_projection_and_new_epo
                 "affects_activity": true,
                 "session_active": session_active,
                 "session_open": true,
-                "session_surface": "cli_terminal"
+                "session_surface": "unknown"
             }),
         );
     };
@@ -3714,6 +3714,14 @@ fn dsh_turn_start_without_message_role_activates_terminal_projection_and_new_epo
             .expect("a real-shape DSH completion remains visible");
         assert_eq!(completed["official_status"], "ready");
         assert_eq!(completed["event"]["event_type"], "done");
+        assert_eq!(
+            completed["overlay_display"]["navigation"]["capability"],
+            "unavailable"
+        );
+        assert_eq!(
+            completed["overlay_display"]["navigation"]["surface"],
+            "unknown"
+        );
 
         let retried = sessions
             .iter()

--- a/docs/integrations/agent-connectors.md
+++ b/docs/integrations/agent-connectors.md
@@ -38,9 +38,17 @@ Adapters record the actual App or CLI origin. Audited App markers override inher
 | Claude Code | Claude App host activation only | Exact Warp URL when present; otherwise known terminal host |
 | OpenCode | OpenCode App host activation only | Exact Warp URL when present; otherwise known terminal host |
 | Pi | No App surface | Exact Warp URL when present; otherwise known terminal host |
-| DeepSeek Harness | No App surface | Exact Warp URL when present; otherwise known terminal host |
+| DeepSeek Harness | Web UI; exact-session return unavailable | Headless is one-shot and has no return target |
 
 Claude hook UUIDs identify CLI transcripts, not existing Claude Desktop sessions, so they are never published as exact Desktop routes. Unknown terminals, malformed targets, source/surface mismatches, and ambiguous historical origins are unavailable rather than guessed. A source-matching audited App origin remains authoritative within one activity epoch even if a later terminal hook loses the marker; a genuine new activation may select a different surface.
+
+The managed DeepSeek Harness connector runs in the default Web profile. DSH's
+browser client selects a session through page-local `sessions.open(sessionId)`
+state and currently exposes only the Web UI root URL, not an externally
+addressable session URL or command. DSH events therefore publish an unknown
+surface with unavailable navigation: inherited `TERM_PROGRAM` and Warp focus
+metadata from the shell that launched the Web server are deliberately ignored,
+because returning to that terminal cannot locate the browser session.
 
 Rows expose `exact_session`, `agent_host`, or `unavailable`. The App acknowledges a completed row only after its declared route succeeds. Opening a host after an exact deep-link failure is recovery assistance, not proof that the session opened, so the row remains visible with a retryable error.
 


### PR DESCRIPTION
## Development claim / 开发声明

- Domain: `agent-connections`
- Claim: `dsh-connector`
- Base commit: `d43a51e4deb0aaf5e1461b0552e800dfa049583a`
- Release preparation: `no`
- Focused validation:
  - `cargo test -p petcore --test integration_d --locked`
  - `./script/validate_connectors_runtime.sh`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":1,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-19T11:44:34Z","train_conflict_resolutions":0} -->