### PR TITLE
Prepare Agent Pet Companion 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ Keep each user-visible change in its own bullet. Write the English text first, t
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-19
+
+### Changed / 变更
+
+<!-- apc-fragment:20260819-standalone-session-title-width -->
+- Standalone Agent session bubbles cap long visual titles at two thirds of the summary line so retained replies remain visible.
+
+  独立 Agent 会话气泡将过长标题的可视宽度限制为摘要行的三分之二，为后续回复保留展示空间。
+
+### Fixed / 修复
+
+<!-- apc-fragment:20260819-dsh-web-session-navigation -->
+- DeepSeek Harness Web sessions no longer appear as CLI sessions or route bubbles back to the terminal that launched the Web server.
+
+  DeepSeek Harness Web 会话不再显示为 CLI，也不会从气泡跳回启动 Web 服务的终端。
 ## [0.5.0] - 2026-08-19
 
 ### Added / 新增

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petcore"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hex",
  "image",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "petcore",
  "petcore-types",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-types"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/changes/unreleased/20260819-dsh-web-session-navigation.json
+++ b/changes/unreleased/20260819-dsh-web-session-navigation.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "dsh",
-  "summary_en": "DeepSeek Harness Web sessions no longer appear as CLI sessions or route bubbles back to the terminal that launched the Web server.",
-  "summary_zh": "DeepSeek Harness Web 会话不再显示为 CLI，也不会从气泡跳回启动 Web 服务的终端。"
-}

--- a/changes/unreleased/20260819-standalone-session-title-width.json
+++ b/changes/unreleased/20260819-standalone-session-title-width.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Changed",
-  "scope": "overlay",
-  "summary_en": "Standalone Agent session bubbles cap long visual titles at two thirds of the summary line so retained replies remain visible.",
-  "summary_zh": "独立 Agent 会话气泡将过长标题的可视宽度限制为摘要行的三分之二，为后续回复保留展示空间。"
-}

--- a/crates/petcore-cli/Cargo.toml
+++ b/crates/petcore-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore-types/Cargo.toml
+++ b/crates/petcore-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-types"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore/Cargo.toml
+++ b/crates/petcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
## Summary

- prepare Agent Pet Companion `0.5.1` from the complete frozen two-fragment inventory
- synchronize PetCore, CLI, types, and Cargo lock identities at `0.5.1`
- consume the standalone session title-width improvement and DSH Web session routing fix into the bilingual release changelog

## Impact

This patch release keeps long standalone bubble titles from crowding out retained replies and prevents DeepSeek Harness Web sessions from being mislabeled or routed back to the server-launching terminal.

## Validation

- `python3 script/development_domains.py validate` (11 domains)
- `python3 script/tests/test_validation_tooling.py` (58 passed)
- `./script/validate_build_scripts_safety.sh --static-only`
- `python3 script/tests/test_release_distribution_contracts.py` (45 passed)
- `python3 script/validate_codex_plugin_version.py --base-ref v0.5.0`
- `cargo check --workspace --all-targets --locked`
- `./script/validate_pre_push.sh --base origin/main`
- `./script/changelog_fragments.py require-consumed`
- `./script/changelog_fragments.py policy --base-ref origin/main --release-preparation true`

## Development claim / 开发声明

- Domain: `release-control-plane`
- Claim: `control-plane`
- Base commit: `3b33bf42a64a6aa8891eed3fd585cc60dde6007a`
- Release preparation: `yes`
- Focused validation:
  - `python3 script/tests/test_validation_tooling.py`
  - `./script/validate_build_scripts_safety.sh --static-only`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":2,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-08-19T12:22:13Z","train_conflict_resolutions":0} -->