### PR TITLE
Teach pet skills to recover oversized subjects

### DIFF
--- a/changes/unreleased/20260902-oversized-subject-recovery.json
+++ b/changes/unreleased/20260902-oversized-subject-recovery.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Changed",
+  "scope": "pet-production",
+  "summary_en": "Pet Maker and Studio now distinguish a safely downscalable large source crop from a truly oversized subject, and recover overflowing generations with shared geometry, normalized provider references, and verified multi-row Dreamina layouts instead of post-fitting returned figures.",
+  "summary_zh": "Pet Maker 与 Studio 现在会区分可安全整幅缩小的大尺寸源裁切和真正越界的主体；对于越界生图，改用共享几何、生成端参考图等比缩小及已验证的 Dreamina 多行布局恢复，不再对返回人物事后适配。"
+}

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-pet-companion",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Forward supported Codex task status and bounded conversation display messages to Agent Pet Companion.",
   "hooks": "./hooks/hooks.json",
   "skills": "./skills/"

--- a/script/tests/pet_skills/test_skill_contracts.py
+++ b/script/tests/pet_skills/test_skill_contracts.py
@@ -174,6 +174,7 @@ class ContractSynchronizationTests(unittest.TestCase):
         visual = (
             MAKER / "references" / "visual-production-and-native-resolution.md"
         ).read_text(encoding="utf-8")
+        maker = (MAKER / "SKILL.md").read_text(encoding="utf-8")
         studio = (STUDIO / "SKILL.md").read_text(encoding="utf-8")
         for required in (
             "ChatGPT/Codex built-in `imagegen`",
@@ -212,6 +213,50 @@ class ContractSynchronizationTests(unittest.TestCase):
                 self.assertEqual(crop_w * 13, crop_h * 12)
                 self.assertGreaterEqual(crop_w, 576)
                 self.assertGreaterEqual(crop_h, 624)
+
+        for name, entrypoint in (("maker", maker), ("studio", studio)):
+            with self.subTest(entrypoint=name):
+                normalized = " ".join(entrypoint.split())
+                self.assertIn("larger 12:13 crop", normalized)
+                self.assertIn("overflow", normalized)
+
+        normalized_visual = " ".join(visual.split())
+        for required in (
+            "source-crop capacity and subject occupancy as separate facts",
+            "sole whole-canvas downscale",
+            "provider-input-only normalized copy",
+            "not source-capacity evidence",
+        ):
+            self.assertIn(required, normalized_visual)
+
+        grid_rows = re.findall(
+            r"\| (\d+) \| (\d+)×(\d+) \| (\d+)×(\d+) \| "
+            r"(\d+)×(\d+) \| (\d+)×(\d+) \|",
+            guide,
+        )
+        self.assertEqual(len(grid_rows), 3)
+        for raw_row in grid_rows:
+            (
+                frame_count,
+                columns,
+                rows,
+                canvas_w,
+                canvas_h,
+                slot_w,
+                slot_h,
+                crop_w,
+                crop_h,
+            ) = map(int, raw_row)
+            with self.subTest(recovery_grid=f"{columns}x{rows}"):
+                self.assertEqual(columns * rows, frame_count)
+                self.assertEqual(canvas_w, columns * slot_w)
+                self.assertEqual(canvas_h, rows * slot_h)
+                self.assertLessEqual(crop_w, slot_w)
+                self.assertLessEqual(crop_h, slot_h)
+                self.assertEqual(crop_w * 13, crop_h * 12)
+                self.assertGreaterEqual(crop_w, 576)
+                self.assertGreaterEqual(crop_h, 624)
+                self.assertLessEqual(canvas_w * canvas_h, 16_777_216)
 
     def test_maker_scripts_are_executable_and_parse_as_python(self) -> None:
         for path in sorted((MAKER / "scripts").glob("*.py")):

--- a/skills/agent-pet-maker/SKILL.md
+++ b/skills/agent-pet-maker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-pet-maker
-version: 0.5.8
+version: 0.5.9
 description: Create or revise portable Agent Pet Companion .petpack V3 pets at low, standard, or high resolution from text and optional reference images. Use for new pets, exported-package revisions, action or timing edits, provider-aware image production, motion QA, packaging, or an explicitly requested install.
 ---
 
@@ -76,7 +76,12 @@ python3 <skill-dir>/scripts/petpack_workspace.py capability-missing \
    reference in that order; `high` production may not rely on text-only equal-
    scale control. Verify the returned frame count, order, identity, anatomy,
    action, spacing, subject scale, crop capacity, and flat background before
-   accepting it.
+   accepting it. Apply the shared oversized-subject decision before rejecting a
+   merely larger-than-runtime figure: if the complete subject and blank margin
+   fit one stable larger 12:13 crop, preserve that crop for the sole whole-frame
+   downscale. If it overflows the recorded safe geometry, correct the generation
+   inputs and regenerate; never shrink, fit, recenter, clip, or pad a returned
+   subject into compliance.
 5. Crop stable equal-size 12:13 source windows without resampling. Run every
    new or regenerated crop through the shared transparency script; package only
    its exact-tier runtime PNGs. Accept a state only when the report and every

--- a/skills/agent-pet-maker/references/dreamina-high-production.md
+++ b/skills/agent-pet-maker/references/dreamina-high-production.md
@@ -23,12 +23,14 @@ dreamina text2image \
   --poll=60
 ```
 
-Generate each action with image-to-image at 4K and height 1536. Dreamina 5.0
-Pro does not reliably keep multiple figures equal-sized from text alone, so
-every action row must pass the production base first, its deterministic pose
-guide second, and its separate deterministic size-reference image third. Both
-guides come from the same geometry record and exact request dimensions. Do not
-combine `--ratio` with custom width and height.
+Generate each action with image-to-image at 4K. Dreamina 5.0 Pro does not
+reliably keep multiple figures equal-sized from text alone, so every action
+sheet must pass the production base first, its deterministic pose guide second,
+and its separate deterministic size-reference image third. Both guides come
+from the same geometry record and exact request dimensions. Do not combine
+`--ratio` with custom width and height.
+
+Use these single-row starting layouts when their safe boxes fit the action:
 
 | Frames | Request size | Invisible slot width | Largest centered 12:13 crop per slot |
 | ---: | ---: | ---: | ---: |
@@ -58,6 +60,29 @@ guide is still the deterministic frame-count and registration authority, while
 the separate size reference locks pixel scale and safe crop occupancy.
 Substitute the table width for the authored frame count. Do not approximate an
 unsupported count by adding or removing generated figures.
+
+## Oversized-subject recovery layouts
+
+First apply the shared decision: a complete figure that fits a stable larger
+12:13 crop is normalized by the transparency script and does not need another
+paid call. If a single-row result instead crosses its recorded safe box, use a
+measured smaller `global_scale` and, when applicable, one of these verified
+multi-row alternatives. They increase real per-slot crop capacity within the
+4K canvas pixel budget; they are not permission to split an action into batches.
+
+| Frames | Grid | Request canvas | Slot size | Largest centered 12:13 crop per slot |
+| ---: | ---: | ---: | ---: | ---: |
+| 4 | 2×2 | 3072×3072 | 1536×1536 | 1416×1534 |
+| 6 | 2×3 | 3072×4608 | 1536×1536 | 1416×1534 |
+| 8 | 2×4 | 2720×6144 | 1360×1536 | 1356×1469 |
+
+Author and read these grids left to right, then top to bottom. Before the
+corrected call, regenerate both structural references at the exact new canvas
+dimensions. If the canonical identity image itself overstates occupancy, use
+the provider-input-only proportional-downscale reference procedure from the
+shared visual contract while preserving the untouched original as identity
+authority. Save and inspect the corrected untouched output; prompted layout,
+request dimensions, and the table above never prove returned crop capacity.
 
 ## Polling and credit use
 

--- a/skills/agent-pet-maker/references/transparent-frame-production.md
+++ b/skills/agent-pet-maker/references/transparent-frame-production.md
@@ -144,7 +144,9 @@ Treat a non-zero exit or any `"ok": false` frame as unusable.
 - Keep the recorded equal-size shared action crop. Change it only when canvas
   contact or the deterministic geometry record proves the crop itself wrong;
   never search adjacent per-frame crops. If the subject overflows correct
-  geometry, regenerate it at the proper scale.
+  geometry, follow the shared
+  [oversized-subject recovery](visual-production-and-native-resolution.md#oversized-subject-decision-and-recovery)
+  and regenerate it instead of fitting the returned figure.
 - After that bounded local path, regenerate on a flatter contrasting opaque
   background. If the same source defect occurs twice, change the prompt, key
   choice, or action design instead of extending the parameter search.

--- a/skills/agent-pet-maker/references/visual-production-and-native-resolution.md
+++ b/skills/agent-pet-maker/references/visual-production-and-native-resolution.md
@@ -7,8 +7,9 @@
 3. Production base and action batches
 4. Deterministic pose and size guides
 5. Reference and prompt contract
-6. Failure routing
-7. Runtime-size acceptance
+6. Oversized-subject decision and recovery
+7. Failure routing
+8. Runtime-size acceptance
 
 ## Source-capacity gate
 
@@ -64,9 +65,9 @@ props. Use this production base as reference image 1 for every later
 image-to-image action.
 
 Generate one action per call and normally keep all 4–8 ordered poses in one
-batch. Use one action card that states the intent, exact frame count, left-to-
-right beat order, playback outcome, safe margins, and flat-background rules.
-Immediately inspect the result before another call.
+batch. Use one action card that states the intent, exact frame count, the
+geometry sidecar's reading order, playback outcome, safe margins, and flat-
+background rules. Immediately inspect the result before another call.
 
 Every multi-frame action uses two script-generated structural references: a
 frameless pose guide as reference image 2 and a separate frameless size-
@@ -91,12 +92,25 @@ Create both guide images with one deterministic script, never an image model.
 The script must:
 
 1. Create a pure `#FF00FF` canvas at the target action-sheet dimensions.
-2. Divide it into invisible equal-width slots:
+2. Divide it into invisible equal-size slots. A one-row sheet uses:
 
    ```text
    slot_width = canvas_width / frame_count
    slot_center_x = (frame_index + 0.5) * slot_width
    ```
+
+   A multi-row sheet uses:
+
+   ```text
+   slot_width = canvas_width / columns
+   slot_height = canvas_height / rows
+   slot_center_x = (column + 0.5) * slot_width
+   slot_center_y = (row + 0.5) * slot_height
+   frame_index = row * columns + column
+   ```
+
+   Read multi-row poses left to right, then top to bottom. Do not leave an
+   unused slot that the provider could fill with an extra figure.
 
 3. Compute one largest centered 12:13 crop per slot, then one safe subject box
    inset by at least 10% on every crop edge. Record the canvas, slot centers,
@@ -148,7 +162,7 @@ and clothing design in every pose.
 
 Every action prompt must also require:
 
-- the exact frame count and left-to-right order;
+- the exact frame count and the sidecar's one-row or row-major order;
 - one complete same-scale character in each invisible slot;
 - the same identity, face, outfit, proportions, materials, and camera in every
   pose;
@@ -164,6 +178,45 @@ Every action prompt must also require:
 Choose the output chroma background by the transparency contract. The guide's
 magenta canvas is structural input, not an instruction to copy its color.
 
+## Oversized-subject decision and recovery
+
+Treat source-crop capacity and subject occupancy as separate facts. Measure the
+untouched decoded output before transparency or any resize, including hair,
+ears or earrings, fingers, garment edges, props or effects, and feet or heels.
+
+1. If every complete subject plus exterior blank margin fits the recorded
+   stable equal-size 12:13 crop, and that crop is at least the runtime target,
+   accept the source even when its figure is much larger than the runtime pet.
+   Crop without resampling and let the shared transparency script perform the
+   sole whole-canvas downscale. This preserves the subject-to-canvas ratio and
+   is the normal supported path, not a scale repair.
+2. If any complete subject crosses the safe subject box, touches the crop, or
+   is already clipped, reject the output. Do not choose a tighter or shifted
+   per-frame crop, shrink or recenter the returned figure, expand the cell with
+   padding, or treat a post-fit frame as source evidence.
+3. Correct the generation inputs as one action-wide geometry change. Prefer a
+   sheet orientation or grid with larger equal slots when the provider's real
+   canvas limits allow it, and/or reduce `global_scale` once. Regenerate the
+   pose guide and size-reference image together from the revised sidecar, keep
+   the same authored frame count and order, and make one corrected call.
+4. When the canonical identity reference itself fills most of its image and
+   keeps biasing the provider toward an oversized subject, retain that original
+   as the identity acceptance authority and create a provider-input-only
+   normalized copy. Crop one rectangle containing every visible defining
+   feature and garment edge, proportionally downscale the entire rectangle
+   once, and place it on a larger flat input canvas aligned to the recorded
+   safe box. Never enlarge, warp, mask, restyle, or independently alter body
+   parts. Use the normalized copy only for the corrected generation call; it
+   is not source-capacity evidence, generated source art, or a package frame.
+5. Reinspect the corrected untouched output against the sidecar measurements.
+   If the same occupancy defect remains, change the sheet topology, provider,
+   or action design instead of searching smaller scales or post-processing the
+   returned subjects.
+
+The permission to proportionally downscale a provider input reference does not
+change runtime normalization: output frames still permit only an exact copy or
+one whole-crop linear-light premultiplied-Alpha downscale in the shared script.
+
 ## Failure routing
 
 - Corner marks: move subjects away from all four corners and preserve exterior
@@ -172,10 +225,8 @@ magenta canvas is structural input, not an instruction to copy its color.
   solid background`.
 - Copied guide figures: require complete replacement and forbid retained guide
   pixels.
-- Scale drift or oversized figures: do not fit cells independently. Regenerate
-  both structural guides from one geometry record, reduce `global_scale` once
-  for the whole action when needed, and lock camera distance, head size,
-  shoulder width, full-body pixel height, and safe crop occupancy.
+- Scale drift or oversized figures: follow the oversized-subject decision and
+  recovery above; never fit cells independently.
 - Pose/size disagreement: repair the shared sidecar and regenerate both guides;
   never resize or reposition one reference independently.
 - Whole-subject registration drift: compare Motion QA's per-frame body-anchor

--- a/skills/agent-pet-studio/SKILL.md
+++ b/skills/agent-pet-studio/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-pet-studio
-version: 0.5.8
+version: 0.5.9
 description: Generate or revise low- or standard-resolution Agent Pet Companion .petpack V3 assets from an in-app Studio job, using real image production when external full source is required and a portable Maker handoff for high resolution. Use only inside Agent Pet Companion Studio generation jobs.
 ---
 
@@ -13,11 +13,10 @@ gallery data, sharing metadata, or Agent execution traces.
 
 Always read the sibling Maker contracts for
 [V3 package and timing](../agent-pet-maker/references/petpack-v3.md) and
-[security](../agent-pet-maker/references/security.md). For external full-source
-work, also read the
-[create/modify workflow](../agent-pet-maker/references/create-modify.md),
-[visual-production contract](../agent-pet-maker/references/visual-production-and-native-resolution.md),
-and
+[security](../agent-pet-maker/references/security.md), plus the shared
+[visual-production contract](../agent-pet-maker/references/visual-production-and-native-resolution.md).
+For external full-source work, also read the
+[create/modify workflow](../agent-pet-maker/references/create-modify.md) and
 [transparent-frame contract](../agent-pet-maker/references/transparent-frame-production.md).
 Read the separate
 [Dreamina high guide](../agent-pet-maker/references/dreamina-high-production.md)
@@ -75,19 +74,21 @@ All modes remain limited to `low` and `standard`.
   defaults onto an existing valid V3 package. A requested timing edit requires
   a newly authored complete frame sequence for the affected state.
 - In brief modes, return name, visual brief, palette, `timing_changed`, all nine
-  state motion entries with complete V3 timing, render notes, and
-  `petpack_source`. Render notes must require a deterministic pose guide and a
-  separate deterministic size-reference image with shared slot/crop geometry
-  for every multi-frame action, plus action-intent review of Motion QA's body-
-  anchor and baseline path and the registration-only `motion-align` recovery
-  rule. Set `timing_changed` only for an explicit timing edit.
+  complete V3 state motion entries, render notes, and `petpack_source`. Render notes
+  require a deterministic pose guide, a separate deterministic size-reference
+  image, shared slot/crop geometry, the oversized-subject decision, Motion QA
+  path review, and registration-only `motion-align`. Set `timing_changed` only
+  for an explicit timing edit.
 - In external full-source mode, lock one canonical identity and create actions
   serially. Generate each multi-frame action from the character base plus a
   deterministic pose guide and separate deterministic size-reference image;
   all three references share one recorded slot, crop, baseline, and
   `global_scale` geometry, and text-only equal-scale control is insufficient.
   Generate fully opaque flat-background source art; inspect actual decoded
-  dimensions, subject scale, and stable equal-size 12:13 crops; use
+  dimensions, subject scale, and stable equal-size 12:13 crops. A complete
+  subject plus margin may use a larger 12:13 crop and the sole whole-crop
+  downscale. Regenerate an overflow from corrected geometry or a provider-input-
+  only proportionally reduced reference; never fit it after return. Use
   `../agent-pet-maker/scripts/prepare_transparent_frames.py` for every new or
   regenerated frame. Its closed runtime-size RGB repair and bounded isolated
   low-Alpha fringe warning are authoritative. On a hard failure, rerun only the


### PR DESCRIPTION
## Summary

- Distinguish a safely downscalable large 12:13 source crop from a subject that actually overflows its safe geometry.
- Recover overflow with one action-wide geometry correction, a proportionally reduced provider-only identity reference when needed, and verified Dreamina 4/6/8-frame multi-row layouts.
- Keep post-return subject fitting forbidden, synchronize Maker and Studio, and bump the bundled Codex plugin and Skill version to 0.5.9.

## Validation

- ./script/validate_pre_push.sh
- ./script/validate_pet_skills.sh
- uv run --with pillow python -m unittest discover -s skills/agent-pet-maker/tests -p test_*.py (88 passed)
- cargo test -p petcore --test integration_b --locked (42 passed)

## Development claim / 开发声明

- Domain: maker-generation
- Claim: maker-skills
- Base commit: daee16e7b6893f89a136a8502daa18af3ae6a920
- Release preparation: no
- Focused validation:
  - cargo test -p petcore --test integration_b --locked
  - ./script/validate_pet_skills.sh

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":3,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-09-02T14:07:33Z","train_conflict_resolutions":0} -->