### PR TITLE
docs: distinguish requirements from implementation evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Agent Pet Companion is a native macOS desktop pet app with an AI pet studio, loc
 
 ## Sources And Scope
 
-Use the current user request, then the touched implementation/typed contracts/tests, then the owning document in [docs/README.md](docs/README.md), then the public README. Investigate prose/code disagreements and update the owning document. Keep durable current-state contracts in the repository; task plans, audits, progress logs, and command evidence belong in PRs, CI, issues, or release notes.
+Use the current user request and effective contracts to establish intended behavior; use the touched implementation, schemas, manifests, tests, and runtime evidence to establish current behavior. Follow the [evidence guidance](docs/README.md#evidence-and-intended-behavior--证据与预期行为) when they disagree. Existing code or passing tests alone do not redefine the requirement. Keep durable current-state contracts in the repository; task plans, audits, progress logs, and command evidence belong in PRs, CI, issues, or release notes.
 
 Keep the existing V1 scope: no public galleries, sharing/community features, Petdex import, Codex built-in pet asset export, Windows UI, cloud accounts, or full mission-control platform unless the user changes scope. DeepSeek Harness is supported.
 

--- a/changes/unreleased/20260909-instruction-scope-evidence.json
+++ b/changes/unreleased/20260909-instruction-scope-evidence.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "apc.changelog-fragment.v1",
+  "kind": "Changed",
+  "scope": "docs",
+  "summary_en": "Separate intended behavior from implementation evidence in Agent guidance and the documentation index.",
+  "summary_zh": "在 Agent 约定和文档索引中区分预期行为与实现证据。"
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,14 +2,13 @@
 
 `README.md` and `README.zh-CN.md` are the product entrypoints. This directory contains the durable technical contracts used by maintainers and Agents. / 根目录 README 面向用户；本目录只保存维护者与 Agent 需要长期维护的技术契约。
 
-## Source order / 信息优先级
+## Evidence and intended behavior / 证据与预期行为
 
-1. Current user request / 当前用户要求
-2. Implementation, typed schemas, manifests, and tests / 实现、类型化 schema、manifest 与测试
-3. The owning document below / 下表中负责该主题的文档
-4. Public README / 面向用户的 README
+- Establish intended behavior from the current user request and the effective product, interface, format, and release contracts in the owning documents below. Preserve explicit scope changes. / 根据当前用户要求和下列所属文档中的有效产品、接口、格式及发布契约确认预期行为，保留明确的范围变更。
+- Establish current behavior from the touched implementation, typed schemas, manifests, tests, and runtime evidence. Passing tests support the cases they cover; they do not by themselves define the requirement or prove it is met in every case. / 根据相关实现、类型化 schema、manifest、测试和运行证据确认当前行为；测试通过支持其覆盖的情形，不能独立定义需求或证明所有情形符合需求。
+- Use the public README for the supported user-facing surface and keep it consistent with the owning contracts. / 用公开 README 确认支持的用户功能，并与所属契约保持一致。
 
-When prose disagrees with code, investigate the implementation and update the single owning document. / 文档与实现冲突时，应核对实现并更新唯一负责该主题的文档。
+When evidence and a contract disagree, determine whether the implementation is defective, the document is stale, or a requirement is unresolved. Correct the responsible source and its affected references; do not rewrite a requirement merely to match current code, or describe planned behavior as implemented. Ask only when the unresolved requirement would materially change the result. / 证据与契约冲突时，核实是实现缺陷、文档过时还是需求未定，再修正负责来源及受影响的引用；不为迁就代码而改写需求，也不把计划写成已实现。仅在未定需求会实质改变结果时澄清。
 
 ## Documents / 文档
 


### PR DESCRIPTION
Agent guidance previously ranked existing implementation and tests ahead of documented contracts without distinguishing observed behavior from intended requirements. The root guidance and bilingual documentation index now make that distinction and require investigating whether a disagreement comes from a defect, stale documentation, or an unresolved requirement. Existing product, delivery, and release constraints remain intact.

Validation: the scoped local pre-push checks passed, including source syntax and local Markdown links; the changelog-fragment policy also passed.

## Development claim / 开发声明

- Domain: `release-control-plane`
- Claim: `engineering-speedup`
- Base commit: `d2040c4922d4b021eedc4cd0eae953537c28d0fb`
- Release preparation: `no`
- Focused validation:
  - `python3 script/tests/test_validation_tooling.py`
  - `./script/validate_build_scripts_safety.sh --static-only`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":4,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-09-09T02:21:17Z","train_conflict_resolutions":0} -->