### PR TITLE
Prepare release 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,51 @@ Keep each user-visible change in its own bullet. Write the English text first, t
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-09-11
+
+### Changed / 变更
+
+<!-- apc-fragment:20260902-oversized-subject-recovery -->
+- Pet Maker and Studio distinguish a safely downscalable complete pose from a clipped subject, and recover overflowing generations with shared geometry, normalized provider references, and verified multi-row Dreamina layouts.
+
+  Pet Maker 与 Studio 区分可安全等比缩小的完整姿势与被裁断的主体；对于越界生图，使用共享几何、等比缩小的生成端参考图及已验证的 Dreamina 多行布局恢复。
+<!-- apc-fragment:20260905-codex-astra-project-defaults-c18e327a -->
+- Codex project configuration now selects GPT-6 Astra, with aligned Agent execution guidance and bilingual model setup documentation.
+
+  Codex 项目配置默认选择 GPT-6 Astra，并同步 Agent 执行约定与中英文模型设置文档。
+<!-- apc-fragment:20260905-maker-gpt-6-astra-7c824df1 -->
+- AI Pet Maker now defaults to GPT-6 Astra for new and resumed Codex Studio turns, preserving medium reasoning and explicit model overrides.
+
+  AI 宠物制作的新建与恢复 Codex Studio 回合默认使用 GPT-6 Astra，保留中等推理强度与显式模型覆盖。
+<!-- apc-fragment:20260906-agents-demand-loading-d83f209a -->
+- Condense project Agent guidance into task-based references, preserve product and release boundaries, and correct stale contributor, changelog, and timing documentation.
+
+  将项目 Agent 指令精简为按任务读取入口，保留产品与发布边界，并修正贡献、变更日志及动画时长文档中的旧说明。
+<!-- apc-fragment:20260909-instruction-scope-evidence -->
+- Separate intended behavior from implementation evidence in Agent guidance and the documentation index.
+
+  在 Agent 约定和文档索引中区分预期行为与实现证据。
+<!-- apc-fragment:20260901-imagegen-native-alpha-default -->
+<!-- apc-fragment:20260909-native-alpha -->
+- Codex Maker and Studio prefer native Alpha with verified retry evidence, allow quality-preserving scaling and canvas placement of AI artwork, retain original assessments when reusing outputs, and require consistent final-size motion and complete production validation.
+
+  Codex Maker 与 Studio 优先原生 Alpha 并校验重试记录，允许以成品质量为准缩放和调整 AI 素材画布，复用素材时保留原评审，最终仍要求动作一致性与完整制作验证。
+
+### Fixed / 修复
+
+<!-- apc-fragment:20260824-integration-b-env-flake -->
+- Isolated PetCore integration tests now strip sibling tests' environment overrides and synchronize process creation, preventing unrelated Studio turn timeouts during concurrent runs.
+
+  隔离的 PetCore 集成测试会剥离兄弟测试的环境覆盖变量，并同步进程创建，避免并发运行时出现无关的 Studio 回合超时。
+<!-- apc-fragment:pr66-fork-pr-ci -->
+- Fork and ordinary-branch pull requests can pass required CI without internal automatic-merge tickets; maintainers merge them after validation.
+
+  fork 和普通分支 PR 无需生成内部自动合并票据即可通过必需 CI，并在验证后由维护者手动合并。
+<!-- apc-fragment:pr66-swift-toolchain-docs -->
+- Document Swift 6.2 or newer as the minimum source-build toolchain in the bilingual developer guides.
+
+  在中英文开发指南中明确源码构建最低需要 Swift 6.2 或更新版本。
+
 ## [0.5.2] - 2026-08-24
 
 ### Fixed / 修复

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petcore"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hex",
  "image",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "petcore",
  "petcore-types",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "petcore-types"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/changes/unreleased/20260824-integration-b-env-flake.json
+++ b/changes/unreleased/20260824-integration-b-env-flake.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "testing",
-  "summary_en": "A concurrency flake in the PetCore integration suite is fixed: a transport test's process-wide Studio turn-timeout override could leak into an isolated generation-lifecycle child process and shrink its real 25-minute turn timeout to seconds, surfacing later as an unrelated terminal-message timeout. Isolated children now strip every sibling test's process-wide override and are spawned while holding the process-state lock; a parity test keeps the strip list in sync with the sibling suite.",
-  "summary_zh": "修复 PetCore 集成测试的一个并发 flake：传输层测试进程级设置的 Studio turn 超时覆盖变量可能泄漏进隔离子进程，把真实 25 分钟 turn 超时压成数秒，随后以无关的终态消息超时形式暴露。隔离子进程现在会剥离兄弟测试的全部进程级覆盖变量，并在派生时持有进程状态锁；另加奇偶校验测试保证剥离清单与兄弟套件保持同步。"
-}

--- a/changes/unreleased/20260901-imagegen-native-alpha-default.json
+++ b/changes/unreleased/20260901-imagegen-native-alpha-default.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "pet-production",
-  "summary_en": "Pet production no longer treats ChatGPT/Codex built-in image generation as a production-ready native-Alpha source by default. The previous opaque flat-chroma workflow and bounded transparency pipeline are restored until transparent output is reliably controllable for both direct and reference-image generation.",
-  "summary_zh": "宠物制作不再默认将 ChatGPT/Codex 内置生图视为可投产的原生 Alpha 来源；在直接生图与参考图生图都能可靠控制透明输出之前，恢复此前的不透明纯色背景制作与有界透明化流水线。"
-}

--- a/changes/unreleased/20260902-oversized-subject-recovery.json
+++ b/changes/unreleased/20260902-oversized-subject-recovery.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Changed",
-  "scope": "pet-production",
-  "summary_en": "Pet Maker and Studio now distinguish a safely downscalable large source crop from a truly oversized subject, and recover overflowing generations with shared geometry, normalized provider references, and verified multi-row Dreamina layouts instead of post-fitting returned figures.",
-  "summary_zh": "Pet Maker 与 Studio 现在会区分可安全整幅缩小的大尺寸源裁切和真正越界的主体；对于越界生图，改用共享几何、生成端参考图等比缩小及已验证的 Dreamina 多行布局恢复，不再对返回人物事后适配。"
-}

--- a/changes/unreleased/20260905-codex-astra-project-defaults-c18e327a.json
+++ b/changes/unreleased/20260905-codex-astra-project-defaults-c18e327a.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Changed",
-  "scope": "development",
-  "summary_en": "Codex project configuration now selects GPT-6 Astra, with aligned Agent execution guidance and bilingual model setup documentation.",
-  "summary_zh": "Codex 项目配置默认选择 GPT-6 Astra，并同步 Agent 执行约定与中英文模型设置文档。"
-}

--- a/changes/unreleased/20260905-maker-gpt-6-astra-7c824df1.json
+++ b/changes/unreleased/20260905-maker-gpt-6-astra-7c824df1.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Changed",
-  "scope": "maker",
-  "summary_en": "AI Pet Maker now defaults to GPT-6 Astra for new and resumed Codex Studio turns, preserving medium reasoning and explicit model overrides.",
-  "summary_zh": "AI 宠物制作的新建与恢复 Codex Studio 回合默认使用 GPT-6 Astra，保留中等推理强度与显式模型覆盖。"
-}

--- a/changes/unreleased/20260906-agents-demand-loading-d83f209a.json
+++ b/changes/unreleased/20260906-agents-demand-loading-d83f209a.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Changed",
-  "scope": "development",
-  "summary_en": "Condense project Agent guidance into task-based references, preserve product and release boundaries, and correct stale contributor, changelog, and timing documentation.",
-  "summary_zh": "将项目 Agent 指令精简为按任务读取入口，保留产品与发布边界，并修正贡献、变更日志及动画时长文档中的旧说明。"
-}

--- a/changes/unreleased/20260909-instruction-scope-evidence.json
+++ b/changes/unreleased/20260909-instruction-scope-evidence.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Changed",
-  "scope": "docs",
-  "summary_en": "Separate intended behavior from implementation evidence in Agent guidance and the documentation index.",
-  "summary_zh": "在 Agent 约定和文档索引中区分预期行为与实现证据。"
-}

--- a/changes/unreleased/20260909-native-alpha.json
+++ b/changes/unreleased/20260909-native-alpha.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Changed",
-  "scope": "maker",
-  "summary_en": "Codex Maker and Studio prefer native Alpha with verified retry evidence, allow quality-preserving scaling and canvas placement of AI artwork, retain original assessments when reusing outputs, and require consistent final-size motion and complete production validation.",
-  "summary_zh": "Codex Maker 与 Studio 优先原生 Alpha 并校验重试记录，允许以成品质量为准缩放和调整 AI 素材画布，复用素材时保留原评审，最终仍要求动作一致性与完整制作验证。"
-}

--- a/changes/unreleased/pr66-fork-pr-ci.json
+++ b/changes/unreleased/pr66-fork-pr-ci.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "ci",
-  "summary_en": "Fork and ordinary-branch pull requests can pass required CI without internal automatic-merge tickets; maintainers merge them after validation.",
-  "summary_zh": "fork 和普通分支 PR 无需生成内部自动合并票据即可通过必需 CI，并在验证后由维护者手动合并。"
-}

--- a/changes/unreleased/pr66-swift-toolchain-docs.json
+++ b/changes/unreleased/pr66-swift-toolchain-docs.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": "apc.changelog-fragment.v1",
-  "kind": "Fixed",
-  "scope": "docs",
-  "summary_en": "Document Swift 6.2 or newer as the minimum source-build toolchain in the bilingual developer guides.",
-  "summary_zh": "在中英文开发指南中明确源码构建最低需要 Swift 6.2 或更新版本。"
-}

--- a/crates/petcore-cli/Cargo.toml
+++ b/crates/petcore-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-cli"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore-types/Cargo.toml
+++ b/crates/petcore-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore-types"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/petcore/Cargo.toml
+++ b/crates/petcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petcore"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
Prepare Agent Pet Companion 0.5.3 with synchronized PetCore, CLI, and shared-type versions. Consume the ten frozen unreleased fragments into the bilingual release section, reconcile the superseded native-Alpha notes with the shipped behavior, and preserve every fragment identifier. The independently versioned Codex plugin and both bundled Skills remain at 0.5.10.

Validation:
- `./script/validate_pre_push.sh --base origin/main` passed, including workspace Rust compilation, formatting, source syntax, and links.
- Release-preparation fragment policy passed; all ten frozen identifiers occur exactly once and no fragment remains.
- Plugin/Skill version discipline passed against the latest stable Release, v0.5.2; rendered bilingual Release notes were reviewed.

The GitHub Release dispatch follows successful exact-main CI plus the mandatory 20 cold launches and Computer Use acceptance on that same clean commit.

## Development claim / 开发声明

- Domain: `release-control-plane`
- Claim: `control-plane`
- Base commit: `8ce32ae7ef517a21b63941274890cd72f69d6370`
- Release preparation: `yes`
- Focused validation:
  - `python3 script/tests/test_validation_tooling.py`
  - `./script/validate_build_scripts_safety.sh --static-only`

<!-- apc-engineering-coordination-v1 {"claim_overlap_rejections":5,"merge_tree_conflicts":0,"schema_version":"apc.engineering-coordination.v1","task_created_at":"2026-09-11T07:16:17Z","train_conflict_resolutions":0} -->